### PR TITLE
Add support for KSP-AVC.

### DIFF
--- a/GameData/RemoteTech2/RemoteTech.version
+++ b/GameData/RemoteTech2/RemoteTech.version
@@ -1,7 +1,7 @@
 {
 	"NAME": "RemoteTech",
 	"URL": "https://raw.githubusercontent.com/RemoteTechnologiesGroup/RemoteTech/master/GameData/RemoteTech2/RemoteTech.version",
-	"DOWNLOAD": "",
+	"DOWNLOAD": "https://github.com/RemoteTechnologiesGroup/RemoteTech/releases/latest",
 	"_comment": "Use old-style format to keep compatibility with KSP-AVC Utility 0.3.",
 	"VERSION": {
 		"MAJOR": 1,


### PR DESCRIPTION
This file lets players use either the KSP-AVC utility by @tyrope or the KSP-AVC plugin by @CYBUTEK to check for new releases of RemoteTech. This file will have to be updated with the version number of the latest release (WARNING: do not change the version number on `master` until the release is ready, since the current version of the file works by comparing itself to the repository).

Closes Cilph/RemoteTech2#237. See also RemoteTechnologiesGroup/RemoteTech#33 and Cilph/RemoteTech2#217.
