### PR TITLE
Timewarp - fixed Bug 41

### DIFF
--- a/src/RemoteTech2/Modules/ModuleRTAntenna.cs
+++ b/src/RemoteTech2/Modules/ModuleRTAntenna.cs
@@ -341,7 +341,7 @@ namespace RemoteTech
             if (!IsRTActive) return State.Off;
 
             ModuleResource request = new ModuleResource();
-            float resourceRequest = Consumption * TimeWarp.fixedDeltaTime;
+            float resourceRequest = Consumption * (TimeWarp.fixedDeltaTime / TimeWarp.CurrentRate);
             float resourceAmount = part.RequestResource("ElectricCharge", resourceRequest);
             if (resourceAmount < resourceRequest * 0.9) return State.NoResources;
             


### PR DESCRIPTION
On Timewarp 6 or higher the electric consumption goes up really high. If
u plan a burn in ~70days and u timewarp up the flightcomputer clock
stops to count because you've no energie
