### PR TITLE
ModuleManager 2 support

### DIFF
--- a/GameData/RemoteTech2/RemoteTech_Antennas.cfg
+++ b/GameData/RemoteTech2/RemoteTech_Antennas.cfg
@@ -1,4 +1,4 @@
-@PART[RTShortAntenna1]
+@PART[RTShortAntenna1]:FOR[RemoteTech]
 {
 	TechRequired = flightControl
 	MODULE
@@ -23,7 +23,7 @@
 	}
 }
 
-@PART[RTLongAntenna2]
+@PART[RTLongAntenna2]:FOR[RemoteTech]
 {
 	TechRequired = largeElectrics
 	@MODULE[ModuleAnimateGeneric]
@@ -55,7 +55,7 @@
 	}
 }
 
-@PART[RTLongAntenna3]
+@PART[RTLongAntenna3]:FOR[RemoteTech]
 {
 	TechRequired = specializedElectrics
 	@MODULE[ModuleAnimateGeneric]
@@ -87,7 +87,7 @@
 	}
 }
 
-@PART[RTShortDish1]
+@PART[RTShortDish1]:FOR[RemoteTech]
 {
 	TechRequired = electrics
 	MODULE
@@ -112,7 +112,7 @@
 	}
 }
 
-@PART[RTShortDish2]
+@PART[RTShortDish2]:FOR[RemoteTech]
 {
 	TechRequired = electrics
 	MODULE
@@ -137,7 +137,7 @@
 	}
 }
 
-@PART[RTLongDish1]
+@PART[RTLongDish1]:FOR[RemoteTech]
 {
 	TechRequired = largeElectrics
 	MODULE
@@ -162,7 +162,7 @@
 	}
 }
 
-@PART[RTLongDish2]
+@PART[RTLongDish2]:FOR[RemoteTech]
 {
 	TechRequired = largeElectrics
 	MODULE
@@ -187,7 +187,7 @@
 	}
 }
 
-@PART[RTGigaDish1]
+@PART[RTGigaDish1]:FOR[RemoteTech]
 {
 	TechRequired = advScienceTech
 	@MODULE[ModuleAnimateGeneric]
@@ -220,7 +220,7 @@
 	}
 }
 
-@PART[RTGigaDish2]
+@PART[RTGigaDish2]:FOR[RemoteTech]
 {
 	TechRequired = specializedElectrics
 	MODULE

--- a/GameData/RemoteTech2/RemoteTech_MechJeb.cfg
+++ b/GameData/RemoteTech2/RemoteTech_MechJeb.cfg
@@ -1,4 +1,4 @@
-@PART[mumech_MJ2_AR202]
+@PART[mumech_MJ2_AR202]:AFTER[MechJeb2]
 {
     title = MechJeb 2 (AR202 case) (ModuleSPU)
 	

--- a/GameData/RemoteTech2/RemoteTech_Squad_Antennas.cfg
+++ b/GameData/RemoteTech2/RemoteTech_Squad_Antennas.cfg
@@ -1,4 +1,4 @@
-@PART[launchClamp1]
+@PART[launchClamp1]:FOR[RemoteTech]
 {
 	MODULE
 	{
@@ -7,7 +7,7 @@
 	}
 }
 
-@PART[longAntenna]
+@PART[longAntenna]:FOR[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	
@@ -40,7 +40,7 @@
 	}
 }
 
-@PART[mediumDishAntenna]
+@PART[mediumDishAntenna]:FOR[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	
@@ -80,7 +80,7 @@
 	}
 }
 
-@PART[commDish]
+@PART[commDish]:FOR[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	

--- a/GameData/RemoteTech2/RemoteTech_Squad_Probes.cfg
+++ b/GameData/RemoteTech2/RemoteTech_Squad_Probes.cfg
@@ -1,4 +1,4 @@
-@PART[probeCoreSphere]
+@PART[probeCoreSphere]:FOR[RemoteTech]
 {
 	MODULE
 	{
@@ -20,7 +20,7 @@
 	}
 }
 
-@PART[probeStackLarge]
+@PART[probeStackLarge]:FOR[RemoteTech]
 {
 	MODULE
 	{
@@ -43,7 +43,7 @@
 	}
 }
 
-@PART[probeStackSmall]
+@PART[probeStackSmall]:FOR[RemoteTech]
 {
 	MODULE
 	{
@@ -65,7 +65,7 @@
 	}
 }
 
-@PART[probeCoreOcto]
+@PART[probeCoreOcto]:FOR[RemoteTech]
 {
 	MODULE
 	{
@@ -87,7 +87,7 @@
 	}
 }
 
-@PART[probeCoreOcto2]
+@PART[probeCoreOcto2]:FOR[RemoteTech]
 {
 	MODULE
 	{
@@ -109,7 +109,7 @@
 	}
 }
 
-@PART[probeCoreHex]
+@PART[probeCoreHex]:FOR[RemoteTech]
 {
 	MODULE
 	{
@@ -131,7 +131,7 @@
 	}
 }
 
-@PART[probeCoreCube]
+@PART[probeCoreCube]:FOR[RemoteTech]
 {
 	MODULE
 	{


### PR DESCRIPTION
Added `FOR[RemoteTech]` sections to all ModuleManager patches. This will let config-writers use ModuleManager's new BEFORE-FOR-AFTER framework with RemoteTech. As a side benefit, we will be able to rename `RemoteTech2.dll` (to, say, `RemoteTech3.dll`) without breaking BEFORE, AFTER, or NEEDS sections in 3rd-party configs, as e.g. `NEEDS[RemoteTech]` will always work.
