### PR TITLE
Ships can now be renamed at any time

### DIFF
--- a/src/RemoteTech2/Modules/ModuleSPU.cs
+++ b/src/RemoteTech2/Modules/ModuleSPU.cs
@@ -49,7 +49,7 @@ namespace RemoteTech
         /// Contains the names of any events that should always be run, 
         /// regardless of connection status or signal delay
         /// </summary>
-        private static readonly List<String> eventWhiteList = new List<String>() {
+        private static readonly HashSet<String> eventWhiteList = new HashSet<String>() {
             "RenameVessel", "RenameAsteroidEvent"
         };
 


### PR DESCRIPTION
Fixed #20.

If in the future we decide other commands should be always available, simply add them to `ModuleSPU.eventWhiteList`.
