### PR TITLE
Add KSPAssembly to AssemblyInfo.cs to allow cleaner dependent DLL linking

### DIFF
--- a/src/RemoteTech2/Properties/AssemblyInfo.cs
+++ b/src/RemoteTech2/Properties/AssemblyInfo.cs
@@ -34,3 +34,8 @@ using System.Runtime.InteropServices;
 // [assembly: AssemblyVersion("1.0.*")]
 [assembly: AssemblyVersion("1.0.0.0")]
 [assembly: AssemblyFileVersion("1.0.0.0")]
+
+// Use KSPAssembly to allow other DLLs to make this DLL a dependency in a
+// non-hacky way in KSP.  Format is (AssemblyProduct, major, minor), and it
+// does not appear to have a hard requirement to match the assembly version.
+[assembly: KSPAssembly("RemoteTech2", 1, 4)]


### PR DESCRIPTION
See http://forum.kerbalspaceprogram.com/threads/57603-0-23-5-RasterPropMonitor-make-your-IVA-a-glass-cockpit-%28v0-16%29-20-Apr?p=1229827&viewfull=1#post1229827
