### PR TITLE
More precise slewing

### DIFF
--- a/src/RemoteTech2/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech2/FlightComputer/FlightComputer.cs
@@ -64,6 +64,16 @@ namespace RemoteTech
         public IEnumerable<ICommand> ActiveCommands { get { return mActiveCommands.Values; } }
         public IEnumerable<ICommand> QueuedCommands { get { return mCommandQueue; } }
 
+        // Flight controller parameters from MechJeb, copied from master on June 27, 2014
+        public PIDControllerV2 pid { get; private set; }
+        public Vector3d lastAct { get; set; }
+        public double Tf = 0.3;
+        public double TfMin = 0.1;
+        public double TfMax = 0.5;
+        public double kpFactor = 3;
+        public double kiFactor = 6;
+        public double kdFactor = 0.5;
+
         private readonly SortedDictionary<int, ICommand> mActiveCommands = new SortedDictionary<int, ICommand>();
         private readonly List<ICommand> mCommandQueue = new List<ICommand>();
         private readonly PriorityQueue<DelayedFlightCtrlState> mFlightCtrlQueue = new PriorityQueue<DelayedFlightCtrlState>();
@@ -79,6 +89,9 @@ namespace RemoteTech
             SignalProcessor = s;
             Vessel = s.Vessel;
             SanctionedPilots = new List<Action<FlightCtrlState>>();
+            pid = new PIDControllerV2(0, 0, 0, 1, -1);
+            initPIDParameters();
+            lastAct = Vector3d.zero;
 
             var target = TargetCommand.WithTarget(FlightGlobals.fetch.VesselTarget);
             mActiveCommands[target.Priority] = target;
@@ -145,6 +158,9 @@ namespace RemoteTech
                 Vessel = SignalProcessor.Vessel;
             }
             Vessel.OnFlyByWire = OnFlyByWirePre + Vessel.OnFlyByWire + OnFlyByWirePost;
+
+            // Update proportional controller for changes in ship state
+            updatePIDParameters();
 
             // Send updates for Target / Maneuver
             TargetCommand last = null;
@@ -262,6 +278,36 @@ namespace RemoteTech
             {
                 pilot.Invoke(fcs);
             }
+        }
+
+        public void initPIDParameters()
+        {
+            pid.Kd = kdFactor / Tf;
+            pid.Kp = pid.Kd / (kpFactor * Math.Sqrt(2) * Tf);
+            pid.Ki = pid.Kp / (kiFactor * Math.Sqrt(2) * Tf);
+            pid.intAccum = Vector3.ClampMagnitude(pid.intAccum, 5);
+        }
+
+        // Calculations of Tf are not safe during FlightComputer constructor
+        // Probably because the ship is only half-initialized...
+        public void updatePIDParameters()
+        {
+            if (Vessel != null) {
+                Vector3d torque = kOS.SteeringHelper.GetTorque (Vessel, 
+                    Vessel.ctrlState != null ? Vessel.ctrlState.mainThrottle : 0.0f);
+                var CoM = Vessel.findWorldCenterOfMass ();
+                var MoI = Vessel.findLocalMOI (CoM);
+
+                Vector3d ratio = new Vector3d (
+                                 torque.x != 0 ? MoI.x / torque.x : 0,
+                                 torque.y != 0 ? MoI.y / torque.y : 0,
+                                 torque.z != 0 ? MoI.z / torque.z : 0
+                             );
+
+                Tf = Mathf.Clamp ((float)ratio.magnitude / 20f, 2 * TimeWarp.fixedDeltaTime, 1f);
+                Tf = Mathf.Clamp ((float)Tf, (float)TfMin, (float)TfMax);
+            }
+            initPIDParameters();
         }
     }
 }

--- a/src/RemoteTech2/FlightComputer/PIDControllerV2.cs
+++ b/src/RemoteTech2/FlightComputer/PIDControllerV2.cs
@@ -1,0 +1,82 @@
+﻿/// <summary>
+/// Proportional controller for KSP autopilots
+/// </summary>
+/// <description>
+/// This is a copy of MechJeb's proportional controller, downloaded by Starstrider42 
+///     from master on June 27, 2014
+/// </description>
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using UnityEngine;
+
+namespace RemoteTech
+{
+    // This PID Controler is used by Raf04 patch for the attitude controler. They have a separate implementation since they use
+    // a different set of argument and do more (and less) than the other PID controler
+    public class PIDControllerV2 : IConfigNode
+    {
+        public Vector3d intAccum, derivativeAct, propAct;
+        public double Kp, Ki, Kd, max, min;
+
+        public PIDControllerV2(double Kp = 0, double Ki = 0, double Kd = 0, double max = double.MaxValue, double min = double.MinValue)
+        {
+            this.Kp = Kp;
+            this.Ki = Ki;
+            this.Kd = Kd;
+            this.max = max;
+            this.min = min;
+            Reset();
+        }
+
+        public Vector3d Compute(Vector3d error, Vector3d omega )
+        {
+            derivativeAct = omega * Kd;
+
+            // integral actíon + Anti Windup
+            intAccum.x = (Math.Abs(derivativeAct.x) < 0.6 * max) ? intAccum.x + (error.x * Ki * TimeWarp.fixedDeltaTime) : 0.9 * intAccum.x;
+            intAccum.y = (Math.Abs(derivativeAct.y) < 0.6 * max) ? intAccum.y + (error.y * Ki * TimeWarp.fixedDeltaTime) : 0.9 * intAccum.y;
+            intAccum.z = (Math.Abs(derivativeAct.z) < 0.6 * max) ? intAccum.z + (error.z * Ki * TimeWarp.fixedDeltaTime) : 0.9 * intAccum.z;
+
+            propAct = error * Kp;
+
+            Vector3d action = propAct + derivativeAct + intAccum;
+
+            // action clamp
+            action = new Vector3d(Math.Max(min, Math.Min(max, action.x)),
+                Math.Max(min, Math.Min(max, action.y)),
+                Math.Max(min, Math.Min(max, action.z)) );
+            return action;
+        }
+
+        public void Reset()
+        {
+            intAccum = Vector3d.zero;
+        }
+
+        public void Load(ConfigNode node)
+        {
+            if (node.HasValue("Kp"))
+            {
+                Kp = Convert.ToDouble(node.GetValue("Kp"));
+            }
+            if (node.HasValue("Ki"))
+            {
+                Ki = Convert.ToDouble(node.GetValue("Ki"));
+            }
+            if (node.HasValue("Kd"))
+            {
+                Kd = Convert.ToDouble(node.GetValue("Kd"));
+            }
+        }
+
+        public void Save(ConfigNode node)
+        {
+            node.SetValue("Kp", Kp.ToString());
+            node.SetValue("Ki", Ki.ToString());
+            node.SetValue("Kd", Kd.ToString());
+        }
+    }
+}


### PR DESCRIPTION
This patch replaces the internals of the RemoteTech flight computer with the corresponding MechJeb code, including their PID controller and a manual calculation of the ship's rotational inertia. I've tested it briefly with both a light and a heavy ship, and it appears to slew to any direction with no wobbling or tumbling. This patch does **not** include the RCS fix in RemoteTechnologiesGroup/RemoteTech#97. At the moment, ships slewing via a mix of reaction wheels and RCS never quite settle down, likely because they're overcompensating for small errors.

In addition to ripping out the guts of `FlightCore`, this patch adds some vessel-state code to `FlightComputer`, and I'd like feedback from someone familiar with the RemoteTech codebase on whether that's the most appropriate place for it.

Test version is up at https://github.com/Starstrider42/RemoteTech/releases/tag/slew-fix-1 if you'd like to try it on a bigger variety of ships.

EDIT: Fixes #76. Does NOT address #25, so they are in fact separate bugs.
