### PR TITLE
Shorter and more generic probe configuration file

### DIFF
--- a/GameData/RemoteTech2/RemoteTech_Squad_Probes.cfg
+++ b/GameData/RemoteTech2/RemoteTech_Squad_Probes.cfg
@@ -1,16 +1,16 @@
-@PART[probeCoreSphere]
+@PART[*]:HAS[@MODULE[ModuleCommand]:HAS[#minimumCrew[0]]]:FOR[RemoteTech]
 {
 	MODULE
 	{
 		name = ModuleSPU
 	}
-	
+
 	MODULE
 	{
 		name = ModuleRTAntennaPassive
 		TechRequired = unmannedTech
 		OmniRange = 3000
-		
+
 		TRANSMITTER
 		{
 			PacketInterval = 0.3
@@ -19,136 +19,10 @@
 		}
 	}
 }
-
 @PART[probeStackLarge]
 {
-	MODULE
+	@MODULE[ModuleSPU]
 	{
-		name = ModuleSPU
 		IsRTCommandStation = true
-	}
-	
-	MODULE
-	{
-		name = ModuleRTAntennaPassive
-		TechRequired = unmannedTech
-		OmniRange = 3000
-		
-		TRANSMITTER
-		{
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
-		}
-	}
-}
-
-@PART[probeStackSmall]
-{
-	MODULE
-	{
-		name = ModuleSPU
-	}
-	
-	MODULE
-	{
-		name = ModuleRTAntennaPassive
-		TechRequired = unmannedTech
-		OmniRange = 3000
-		
-		TRANSMITTER
-		{
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
-		}
-	}
-}
-
-@PART[probeCoreOcto]
-{
-	MODULE
-	{
-		name = ModuleSPU
-	}
-	
-	MODULE
-	{
-		name = ModuleRTAntennaPassive
-		TechRequired = unmannedTech
-		OmniRange = 3000
-		
-		TRANSMITTER
-		{
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
-		}
-	}
-}
-
-@PART[probeCoreOcto2]
-{
-	MODULE
-	{
-		name = ModuleSPU
-	}
-	
-	MODULE
-	{
-		name = ModuleRTAntennaPassive
-		TechRequired = unmannedTech
-		OmniRange = 3000
-		
-		TRANSMITTER
-		{
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
-		}
-	}
-}
-
-@PART[probeCoreHex]
-{
-	MODULE
-	{
-		name = ModuleSPU
-	}
-	
-	MODULE
-	{
-		name = ModuleRTAntennaPassive
-		TechRequired = unmannedTech
-		OmniRange = 3000
-		
-		TRANSMITTER
-		{
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
-		}
-	}
-}
-
-@PART[probeCoreCube]
-{
-	MODULE
-	{
-		name = ModuleSPU
-	}
-	
-	MODULE
-	{
-		name = ModuleRTAntennaPassive
-		TechRequired = unmannedTech
-		OmniRange = 3000
-		
-		TRANSMITTER
-		{
-			PacketInterval = 0.3
-			PacketSize = 2
-			PacketResourceCost = 15.0
-		}
 	}
 }


### PR DESCRIPTION
Use ModuleManager extended syntax to automatically add RemoteTech2 module
to probes. Setting command station capatiblity is still manual.
