### PR TITLE
Added virtual tech node for probe core passive antennas.

### DIFF
--- a/GameData/RemoteTech2/RemoteTech_Tech_Node.cfg
+++ b/GameData/RemoteTech2/RemoteTech_Tech_Node.cfg
@@ -13,6 +13,6 @@ PART {
 	cost = 0
 	category = none
 
-	title = Probe Core Uprade
+	title = Probe Core Upgrade
 	description = Allows RemoteTech probe cores to contact ships within 3 km without the need for a dedicated antenna.
 }


### PR DESCRIPTION
This patch resolves #52 by creating a dummy part in the tech tree that informs players that their probe cores now have a passive antenna. Naturally, the description will need to be changed if we ever allow some cores to get passive antennas at nodes other than Unmanned Tech.

![Appearance in tech tree](https://cloud.githubusercontent.com/assets/6760782/4100743/f35f2fd8-30b1-11e4-80e7-550bf3b21193.png)
