### PR TITLE
Travis unix line endings

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -2,6 +2,9 @@
 # Set default behavior to automatically normalize line endings.
 ###############################################################################
 * text=auto
+*.cfg text eol=crlf
+*.version text eol=crlf
+*.txt text eol=crlf
 
 ###############################################################################
 # Set default behavior for command prompt diff.


### PR DESCRIPTION
Keep the windows line endings by checking out the repository. This will
fix #99
