### PR TITLE
Added official support for B9 probe cores. Resolves #173.

### DIFF
--- a/GameData/RemoteTech2/RemoteTech_B9_Probes.cfg
+++ b/GameData/RemoteTech2/RemoteTech_B9_Probes.cfg
@@ -1,0 +1,35 @@
+@PART[B9_Cockpit_D25]:AFTER[B9_Aerospace]
+{
+	%MODULE[ModuleSPU] {
+		%IsRTCommandStation = true
+		%RTCommandMinCrew = 6
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}
+
+@PART[B9_Cockpit_MK1_Control_ACU]:AFTER[B9_Aerospace]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}


### PR DESCRIPTION
This patch includes stockalike RemoteTech configs for the MK1 Heavy-duty Remote Guidance Unit and D25 Heavy Drone Core. The latter can serve as the computer for a command station, just like the RC-L01 Remote Guidance Unit.

Resolves #173.
