### PR TITLE
Corrected path length calculation.

### DIFF
--- a/src/RemoteTech2/NetworkPathfinder.cs
+++ b/src/RemoteTech2/NetworkPathfinder.cs
@@ -18,7 +18,6 @@ namespace RemoteTech
             var nStart = new Node<NetworkLink<T>>(new NetworkLink<T>(start, null, LinkType.None), 0, heuristicFunction.Invoke(start, goal), null, false);
             nodeMap[start] = nStart;
             priorityQueue.Enqueue(nStart);
-            double cost = 0;
 
             while (priorityQueue.Count > 0)
             {
@@ -32,10 +31,9 @@ namespace RemoteTech
                     for (var node = current; node.From != null; node = node.From)
                     {
                         reversePath.Add(node.Item);
-                        cost += node.Cost;
                     }
                     reversePath.Reverse();
-                    return new NetworkRoute<T>(start, reversePath, cost);
+                    return new NetworkRoute<T>(start, reversePath, current.Cost);
                 }
 
                 foreach (var link in neighborsFunction.Invoke(current.Item.Target))


### PR DESCRIPTION
Per @Cilph's suggestion, I replaced the summed cost over all nodes along a path with the cost of the destination node. Some quick testing in Kerbin orbit confirms that communication times behave more consistently than reported by @bk2w at Cilph/RemoteTech2Archived#219.

 Fixed #11.

EDIT: GAH, I give up on how to close an issue from a pull request.
