### PR TITLE
Updated to KSP-AVC Plugin 1.1.3 or later.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,0 +1,145 @@
+Version 1.4.1
+========================================
+Released August 28, 2014
+
+Features:
+--------------------
+
+* Compatible with KSP 0.24. Some part costs have changed.
+
+Bug Fixes:
+--------------------
+
+* Flight computer now slews much more accurately and efficiently.
+* Flight computer will now take RCS thrust into account when slewing.
+* Signal delay window is now sized properly for all Flight GUI settings.
+* Ships can now be renamed from the right-click menu at any time. Note that they can still be renamed from the tracking station.
+* Reverted 1.4.0 fix for electric charge consumption at higher time-warp factors (fix was causing electricity use to be underestimated).
+* Fixed conflicts with mods that depend on RemoteTech.
+* Reduced logging should cause less lag.
+
+Version 1.4.0
+========================================
+Released June 16, 2014
+
+Features:
+--------------------
+
+* KSP-AVC Support
+* EXEC commands are now executed at the correct time in advance of the maneuver node (accounts for signal delay and vessel acceleration)
+* Added logging to API - useful for developers of mods that wish to interact with RT - requires `VERBOSE_DEBUG_LOG = True` in `settings.cfg`
+
+Bug Fixes:
+--------------------
+
+* Fixed display of execution delay for simple commands such as running experiments
+* **Significantly reduced** occurrences of the dreaded 'vessel duplication' bug
+* Fixed display of the Flight Computer icon below the time-warp/clock display in the upper-left of the screen
+* Fixed electric charge consumption at higher time-warp factors
+* Prevented flight computer from crashing when scheduling a Maneuver Node Execution ('EXEC') command when no engines are active
+* Fixed orientation when orienting in Target ('TGT') reference frame
+* Fixed calculation of burn time for EXEC commands when engine thrust limit is less than 100%
+* Fixed calculation of burn time for EXEC commands when using ModuleEnginesFX parts (eg. NASA 'Kerbodyne' engines)
+
+Version 1.3.3
+========================================
+Released December 26, 2013
+
+* 0.23 compatible;
+* Switch vessel focus on the map view, allowing easy editing of targets;
+* Flight Computer rewrite;
+* Some UI elements were rewritten;
+* Node Execution;
+* Tweaks, bug fixes;
+
+Version 1.2.7
+========================================
+
+* Tweaked per-frame load-balancing and fixed a divide-by-zero;
+* ModuleManager 1.5 by Sarbian. **Please delete the old one;**
+* Static class serving as API for future kOS integration;
+* Fixed bug in TimeWarp throttling.
+
+Version 1.2.6
+========================================
+
+* Fixed settings file not auto-generating;
+* Fixed collection modified exception;
+* Possibly fixed throttle jitter again?;
+* Fixed Target/Maneuver in Flight Computer;
+* Disable SAS when Flight Computer is on;
+* Tweaked time warp throttling when commands are approaching.
+
+Version 1.2.1
+========================================
+
+* Removed kOS integration.
+
+Version 1.2.0
+========================================
+
+* Fixed (probably) the bug that humiliated me in one of Scott Manley's videos;
+* Flight Computer and kOS integration! (details below); Requires patched dll for now!
+* Fixed Delta-V burns; Cilph can't do basic vector math late at night;
+* "N/A" on TimeQuadrant when no SPU is available; "Connected" when signal delay is disabled;
+* Allow docking node targeting when the other vessel is disconnected;
+* Halved antenna power consumption;
+* Signal Delay is now on by default;
+* Quick hack to not cache lines/cones that are disabled to increase performance for some;
+* Possible fix for long range planet targeting being twitchy;
+* Two new dish parts by Kommit! The KR-7 and KR-14 replace the SS-5 and LL-5 respectively. The old parts will be deprecated but still included so as not to break existing crafts;
+* Settings File is now properly created on load.
+
+###kOS integration:
+* All immediate mode actions now require signal delay to pass;
+* Steering locks now work when the vessel is disconnected;
+* Action groups no longer trigger when kOS has them blocked;
+* "BATCH" and "DEPLOY" commands to send a list of commands as one packet;
+* ~~Requires patched kOS DLL until I merge the changes. Download here.~~
+
+###Flight Computer:
+* Works pretty much like MechJeb's SmartASS;
+* Use "Enter" to confirm changes in most text fields;
+* Duration format: "12h34m45s" or "12345" for plain seconds;
+* Delta-V burn format: "1234m/s";
+* Cancel commands by clicking on the X in the queue, sends signal ASAP, but delay still applies.
+* Use the queue to view any delayed command; even right-click menu events.
+
+
+Version 1.1.0
+========================================
+
+
+* Added a settings file; auto-generates ~~once the plugin loads.~~ once forced to save by editing the map filter.
+* Filter in map view now properly saves.
+* Tracking Station should now save changes made to dishes.
+* Fixed NPE in editor due to recent ModuleSPUPassive changes
+* ModuleRTAntennaPassive now correctly works when unloaded
+* Dishes can now target the active vessel.
+* Promised Flight Computer NOT enabled yet. The new Squad SAS is too unstable for auto-piloting.
+* Signal Delay can be enabled in settings file. Good luck without that flight computer.
+
+Version 1.0.7
+========================================
+
+
+* Fixed NPE when antennas did not have satellites during rendering.
+* ModuleSPUPassive now provides unloaded routing if the craft was controllable as a whole. Might have lead to unintentional bugs. (vardicd)
+
+Version 1.0.6
+========================================
+
+* Fixed science transmissions not sending all of the data. (Kethevin)
+
+Version 1.0.5
+========================================
+
+* Fix MechJeb fighting over throttle.
+* Added ModuleSPU to radial MechJeb AR202 casing. This kills functionality if connection is lost.
+* Fix queuing for science transmissions. (Ralathon)
+* Added a ScreenMessage if your partmenu events are blocked due to signal loss.
+
+Version 1.0
+========================================
+
+* Initial release!

--- a/GameData/RemoteTech2/RemoteTech.version
+++ b/GameData/RemoteTech2/RemoteTech.version
@@ -1,7 +1,7 @@
 {
 	"NAME": "RemoteTech",
 	"URL": "https://raw.githubusercontent.com/RemoteTechnologiesGroup/RemoteTech/master/GameData/RemoteTech2/RemoteTech.version",
-	"CHANGE_LOG_URL": "", 
+	"CHANGE_LOG_URL": "https://raw.githubusercontent.com/RemoteTechnologiesGroup/RemoteTech/master/CHANGES.md", 
 	"GITHUB":
 	{
 		"_comment": "GitHub support requires build tags that include a #.#.# string",


### PR DESCRIPTION
Tyrope's KSP-AVC Utility is now defunct, and doesn't need to be supported; only cybutek's KSP-AVC Plugin will be supported going forward.

So long as we use GitHub release tags that include the version number in them, we don't need to worry about race conditions between updating the online `.version` file and actually publishing the release; the version inferred from the latest release tag will override the version in the `.version` file. Same goes for the download location; we needn't update it manually.

EDIT: clarified wording based on pjf's post
