### PR TITLE
Moved function getLocks

### DIFF
--- a/src/RemoteTech2/RTCore.cs
+++ b/src/RemoteTech2/RTCore.cs
@@ -60,13 +60,13 @@ namespace RemoteTech
             var vs = Satellites[FlightGlobals.ActiveVessel];
             if (vs != null)
             {
+                GetLocks();
                 if (vs.HasLocalControl)
                 {
                     ReleaseLocks();
                 }
                 else if (vs.FlightComputer != null && vs.FlightComputer.InputAllowed)
                 {
-                    GetLocks();
                     foreach (KSPActionGroup ag in GetActivatedGroup())
                     {
                         vs.FlightComputer.Enqueue(ActionGroupCommand.WithGroup(ag));


### PR DESCRIPTION
This will fix #95 and also fix #24 that you can toggle sas,rsc or action groups anymore
without a connection after undocking.
