### PR TITLE
Fixed the registration of mission control

### DIFF
--- a/src/RemoteTech2/NetworkManager.cs
+++ b/src/RemoteTech2/NetworkManager.cs
@@ -238,6 +238,7 @@ namespace RemoteTech
             {
                 antenna.Parent = this;
             }
+            this.mGuid = new Guid(this.Guid);
         }
 
         public override String ToString()


### PR DESCRIPTION
Fixed the registration of mission control for a fresh installation of rt without a settings.cfg. 

Fixes #174 
