### PR TITLE
Removed event queue freeze when power lost.

### DIFF
--- a/src/RemoteTech2/FlightComputer/Commands/AbstractCommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/AbstractCommand.cs
@@ -22,6 +22,7 @@ namespace RemoteTech
                 return "";
             }
         }
+        public abstract String ShortName { get; }
         public virtual int Priority { get { return 255; } }
 
         // true: move to active.

--- a/src/RemoteTech2/FlightComputer/Commands/ActionGroupCommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/ActionGroupCommand.cs
@@ -11,8 +11,9 @@ namespace RemoteTech
 
         public override string Description
         {
-            get { return "Toggle " + ActionGroup + Environment.NewLine + base.Description; }
+            get { return ShortName + Environment.NewLine + base.Description; }
         }
+        public override string ShortName { get { return "Toggle " + ActionGroup; } }
 
         public override bool Pop(FlightComputer f)
         {

--- a/src/RemoteTech2/FlightComputer/Commands/AttitudeCommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/AttitudeCommand.cs
@@ -81,6 +81,13 @@ namespace RemoteTech
         {
             get
             {
+                return ShortName + Environment.NewLine + base.Description;
+            }
+        }
+        public override string ShortName
+        {
+            get
+            {
                 String res = "";
                 switch (Mode)
                 {
@@ -97,7 +104,7 @@ namespace RemoteTech
                         res = String.Format(FormatMode[Mode], FormatReference[Frame], FormatAttitude[Attitude]);
                         break;
                 }
-                return res + Environment.NewLine + base.Description;
+                return res;
             }
         }
 

--- a/src/RemoteTech2/FlightComputer/Commands/BurnCommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/BurnCommand.cs
@@ -16,8 +16,17 @@ namespace RemoteTech
         {
             get
             {
-                return String.Format("Burn {0}, {1}", Throttle.ToString("P2"), Duration > 0 ? RTUtil.FormatDuration(Duration) : (DeltaV.ToString("F2") + "m/s")) + Environment.NewLine + base.Description;
+                return String.Format("Burn {0}, {1}", Throttle.ToString("P2"), burnLength()) + Environment.NewLine + base.Description;
             }
+        }
+        public override string ShortName 
+        { 
+            get { 
+                return String.Format("Execute burn for {0}", burnLength()); 
+            } 
+        }
+        private string burnLength() {
+            return Duration > 0 ? RTUtil.FormatDuration(Duration) : (DeltaV.ToString("F2") + "m/s");
         }
 
         private bool mAbort;

--- a/src/RemoteTech2/FlightComputer/Commands/CancelCommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/CancelCommand.cs
@@ -11,6 +11,7 @@ namespace RemoteTech
         public ICommand Command { get; set; }
 
         public override string Description { get { return "Cancelling a command." + Environment.NewLine + base.Description; } }
+        public override string ShortName { get { return "Cancel command"; } }
 
         public override bool Pop(FlightComputer f)
         {

--- a/src/RemoteTech2/FlightComputer/Commands/ICommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/ICommand.cs
@@ -9,7 +9,10 @@ namespace RemoteTech
     {
         double TimeStamp { get; set; }
         double ExtraDelay { get; set; }
+        // The command description displayed in the flight computer
         String Description { get; }
+        // An abbreviated version of the description for inline inclusion in messages
+        String ShortName { get; }
         int Priority { get; }
 
         bool Pop(FlightComputer f);

--- a/src/RemoteTech2/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/ManeuverCommand.cs
@@ -32,6 +32,7 @@ namespace RemoteTech
                     return "Execute planned maneuver" + Environment.NewLine + base.Description;
             }
         }
+        public override string ShortName { get { return "Execute maneuver node"; } }
 
         public override bool Pop(FlightComputer f)
         {

--- a/src/RemoteTech2/FlightComputer/Commands/TargetCommand.cs
+++ b/src/RemoteTech2/FlightComputer/Commands/TargetCommand.cs
@@ -15,9 +15,10 @@ namespace RemoteTech
         {
             get
             {
-                return ("Target: " + (Target != null ? Target.GetName() : "None")) + Environment.NewLine + base.Description;
+                return ShortName + Environment.NewLine + base.Description;
             }
         }
+        public override string ShortName { get { return "Target: " + (Target != null ? Target.GetName() : "None"); } }
 
         public override bool Pop(FlightComputer f)
         {

--- a/src/RemoteTech2/FlightComputer/EventCommand.cs
+++ b/src/RemoteTech2/FlightComputer/EventCommand.cs
@@ -17,6 +17,13 @@ namespace RemoteTech
                        BaseEvent.GUIName + Environment.NewLine + base.Description;
             }
         }
+        public override string ShortName
+        {
+            get
+            {
+                return BaseEvent.GUIName;
+            }
+        }
          
         public override bool Pop(FlightComputer f)
         {


### PR DESCRIPTION
Events in the flight computer queue will continue counting down, even if the ship does not have power. If there is no power when the event is scheduled to occur, it will be ignored and an error message will be shown to the player.

Fixes RemoteTechnologiesGroup/RemoteTech#41.
