### PR TITLE
High Priority: RT 1.5.0 compatibility fix

### DIFF
--- a/src/RemoteTech/NetworkRenderer.cs
+++ b/src/RemoteTech/NetworkRenderer.cs
@@ -13,6 +13,8 @@ namespace RemoteTech
         Dish   = 2,
         Sphere = 4,
         Cone   = 8,
+        Planet = 8,     // For backward compatibility with RemoteTech 1.4 and earlier
+                        // Cone should be first, so that it's the one that appears in settings file
         Path   = 16
     }
 


### PR DESCRIPTION
Taki117 on the forums discovered that RemoteTech 1.5.0 cannot read settings files written for earlier versions of RemoteTech. And by "cannot read", I mean it causes KSP to lock up while loading.

The culprit is #193, which renames one of the `MapFilter` values from `Planet` to `Cone`. Config files that mention "Planet" as one of the active map overlays cause an infinite loop of exceptions (don't want to know what program structure causes THAT). This patch allows RemoteTech to correctly parse the "Planet" value as a synonym for "Cone", while ensuring that any writing to the settings file still outputs "Cone".
