### PR TITLE
Fix for KSP 0.25 name change

### DIFF
--- a/GameData/RemoteTech/RemoteTech_Tech_Node.cfg
+++ b/GameData/RemoteTech/RemoteTech_Tech_Node.cfg
@@ -5,7 +5,7 @@ PART {
 
 	MODEL
 	{
-		model = Squad/Parts/Command/probeCoreSphere/model
+		model = Squad/Parts/Command/probeStackSphere/model
 	}
 
 	TechRequired = unmannedTech


### PR DESCRIPTION
The passive antenna entry in the tech tree includes a reference to the Stayputnik model, which has changed directories as part of Squad's standardization of part folders.
