### PR TITLE
Fixed the thrust for flameout engines

### DIFF
--- a/src/RemoteTech/FlightComputer/FlightCore.cs
+++ b/src/RemoteTech/FlightComputer/FlightCore.cs
@@ -134,7 +134,7 @@ namespace RemoteTech
         }
 
         /// <summary>
-        /// Get the total thrust of all activated, not flamed engines.
+        /// Get the total thrust of all activated, not flamed out engines.
         /// </summary>
         /// <param name="v">Current vessel</param>
         /// <returns>Total thrust in kN</returns>
@@ -144,6 +144,7 @@ namespace RemoteTech
 
             foreach (var pm in v.parts.SelectMany(p => p.FindModulesImplementing<ModuleEngines>()))
             {
+                // Notice: flameout is only true if you try to perform with this engine not before
                 if (!pm.EngineIgnited || pm.flameout) continue;
                 // check for the needed propellant before changing the total thrust
                 if (!FlightCore.hasPropellant(pm.propellants)) continue;
@@ -152,6 +153,7 @@ namespace RemoteTech
 
             foreach (var pm in v.parts.SelectMany(p => p.FindModulesImplementing<ModuleEnginesFX>()))
             {
+                // Notice: flameout is only true if you try to perform with this engine not before
                 if (!pm.EngineIgnited || pm.flameout) continue;
                 // check for the needed propellant before changing the total thrust
                 if (!FlightCore.hasPropellant(pm.propellants)) continue;

--- a/src/RemoteTech/FlightComputer/FlightCore.cs
+++ b/src/RemoteTech/FlightComputer/FlightCore.cs
@@ -119,6 +119,8 @@ namespace RemoteTech
         /// <returns>True if there are enough propellant to perform</returns>
         public static bool hasPropellant(System.Collections.Generic.List<Propellant> propellants)
         {
+            if (CheatOptions.InfiniteFuel) return true;
+
             foreach (var props in propellants)
             {
                 var total = props.totalResourceCapacity;

--- a/src/RemoteTech/FlightComputer/FlightCore.cs
+++ b/src/RemoteTech/FlightComputer/FlightCore.cs
@@ -113,7 +113,7 @@ namespace RemoteTech
         }
 
         /// <summary>
-        /// Checks the needed propellant of an engine
+        /// Checks the needed propellant of an engine. Its always true if infinite fuel is activ
         /// </summary>
         /// <param name="propellants">Propellant for an engine</param>
         /// <returns>True if there are enough propellant to perform</returns>

--- a/src/RemoteTech/FlightComputer/FlightCore.cs
+++ b/src/RemoteTech/FlightComputer/FlightCore.cs
@@ -112,19 +112,52 @@ namespace RemoteTech
             kOS.SteeringHelper.SteerShipToward(target, fs, f);
         }
 
+        /// <summary>
+        /// Checks the needed propellant of an engine
+        /// </summary>
+        /// <param name="propellants">Propellant for an engine</param>
+        /// <returns>True if there are enough propellant to perform</returns>
+        public static bool hasPropellant(System.Collections.Generic.List<Propellant> propellants)
+        {
+            foreach (var props in propellants)
+            {
+                var total = props.totalResourceCapacity;
+                var require = props.currentRequirement;
+                // check the total capacity and the required amount of proppelant
+                if (total <= 0 || require > total)
+                {
+                    return false;
+                }
+            }
+
+            return true;
+        }
+
+        /// <summary>
+        /// Get the total thrust of all activated, not flamed engines.
+        /// </summary>
+        /// <param name="v">Current vessel</param>
+        /// <returns>Total thrust in kN</returns>
         public static double GetTotalThrust(Vessel v)
         {
             double thrust = 0.0;
+
             foreach (var pm in v.parts.SelectMany(p => p.FindModulesImplementing<ModuleEngines>()))
             {
-                if (!pm.EngineIgnited) continue;
+                if (!pm.EngineIgnited || pm.flameout) continue;
+                // check for the needed propellant before changing the total thrust
+                if (!FlightCore.hasPropellant(pm.propellants)) continue;
                 thrust += (double)pm.maxThrust * (pm.thrustPercentage / 100);
             }
+
             foreach (var pm in v.parts.SelectMany(p => p.FindModulesImplementing<ModuleEnginesFX>()))
             {
-                if (!pm.EngineIgnited) continue;
+                if (!pm.EngineIgnited || pm.flameout) continue;
+                // check for the needed propellant before changing the total thrust
+                if (!FlightCore.hasPropellant(pm.propellants)) continue;
                 thrust += (double)pm.maxThrust * (pm.thrustPercentage / 100);
             }
+
             return thrust;
         }
     }


### PR DESCRIPTION
To get the right amount of thrust for all activated and not flamed out engines we had to check against the needed propellants for the engines.

Closes 243