### PR TITLE
Saves the position of the window

### DIFF
--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -21,6 +21,7 @@ namespace RemoteTech
 
     public class Settings
     {
+        public Dictionary<String, Rect> savedWindowPositions = new Dictionary<String, Rect>();
         [Persistent] public float ConsumptionMultiplier = 1.0f;
         [Persistent] public float RangeMultiplier = 1.0f;
         [Persistent] public String ActiveVesselGuid = "35b89a0d664c43c6bec8d0840afc97b2";

--- a/src/RemoteTech/UI/AntennaWindow.cs
+++ b/src/RemoteTech/UI/AntennaWindow.cs
@@ -17,6 +17,7 @@ namespace RemoteTech
         public AntennaWindow(IAntenna antenna)
             : base(Guid, "Antenna Configuration", new Rect(100, 100, 300, 500), WindowAlign.Floating)
         {
+            mSavePosition = true;
             mSetAntenna = antenna;
             mTargetInfos = new TargetInfoWindow(this, WindowAlign.Floating);
         }

--- a/src/RemoteTech/UI/FlightComputerWindow.cs
+++ b/src/RemoteTech/UI/FlightComputerWindow.cs
@@ -15,6 +15,7 @@ namespace RemoteTech
         public FlightComputerWindow(FlightComputer fc)
             : base(Guid.NewGuid(), "Flight Computer", new Rect(100, 100, 0, 0), WindowAlign.Floating)
         {
+            mSavePosition = true;
             mAttitude = new AttitudeFragment(fc, () => mQueueEnabled = !mQueueEnabled);
             mQueue = new QueueFragment(fc);
             mQueueEnabled = false;


### PR DESCRIPTION
Every window position can be saved by setting the `mSavePosition` to true. Actually i've set this to the FlightComputer and AntennaWindow. I also changed the `onPositionChanged` trigger to get a better result.
The positions will only be saved for this ksp instance.
Fixes #21