### PR TITLE
Default min crew - fix for issue #232

### DIFF
--- a/src/RemoteTech/Modules/ProtoSignalProcessor.cs
+++ b/src/RemoteTech/Modules/ProtoSignalProcessor.cs
@@ -17,8 +17,6 @@ namespace RemoteTech
         public Vessel Vessel { get { return mVessel; } }
         public FlightComputer FlightComputer { get { return null; } }
         public bool IsMaster { get { return true; } }
-
-        public const int DEFAULT_COMMAND_MINIMUM_CREW = 6;
         private readonly Vessel mVessel;
 
         public ProtoSignalProcessor(ProtoPartModuleSnapshot ppms, Vessel v)
@@ -26,7 +24,7 @@ namespace RemoteTech
             mVessel = v;
             Powered = ppms.GetBool("IsRTPowered");
 
-	    int commandMinCrew = DEFAULT_COMMAND_MINIMUM_CREW;
+	    int commandMinCrew = RTSettings.Instance.DefaultMinimumCrew;
 			
             try {
                 commandMinCrew = ppms.GetInt("RTCommandMinCrew");
@@ -35,7 +33,7 @@ namespace RemoteTech
             } catch (ArgumentException) {
                 // I'm assuming this would get thrown by ppms.GetInt()... do the other functions have an exception spec?
                 RTLog.Notify("ProtoSignalProcessor(Powered: {0}, HasCommandStation: {1}, Crew: {2}/{3} [Default]", 
-                    Powered, v.HasCommandStation(), v.GetVesselCrew().Count, DEFAULT_COMMAND_MINIMUM_CREW);
+                    Powered, v.HasCommandStation(), v.GetVesselCrew().Count, RTSettings.Instance.DefaultMinimumCrew);
             }
             IsCommandStation = Powered && v.HasCommandStation() && v.GetVesselCrew().Count >= commandMinCrew;
         }

--- a/src/RemoteTech/Modules/ProtoSignalProcessor.cs
+++ b/src/RemoteTech/Modules/ProtoSignalProcessor.cs
@@ -34,8 +34,8 @@ namespace RemoteTech
                     Powered, v.HasCommandStation(), v.GetVesselCrew().Count, commandMinCrew));
             } catch (ArgumentException) {
                 // I'm assuming this would get thrown by ppms.GetInt()... do the other functions have an exception spec?
-                RTLog.Notify("ProtoSignalProcessor(Powered: {0}, HasCommandStation: {1}, Crew: {2}/6 [Default]", 
-                    Powered, v.HasCommandStation(), v.GetVesselCrew().Count);
+                RTLog.Notify("ProtoSignalProcessor(Powered: {0}, HasCommandStation: {1}, Crew: {2}/{3} [Default]", 
+                    Powered, v.HasCommandStation(), v.GetVesselCrew().Count, DEFAULT_COMMAND_MINIMUM_CREW);
             }
             IsCommandStation = Powered && v.HasCommandStation() && v.GetVesselCrew().Count >= commandMinCrew;
         }

--- a/src/RemoteTech/Modules/ProtoSignalProcessor.cs
+++ b/src/RemoteTech/Modules/ProtoSignalProcessor.cs
@@ -18,7 +18,7 @@ namespace RemoteTech
         public FlightComputer FlightComputer { get { return null; } }
         public bool IsMaster { get { return true; } }
 
-		public const int DEFAULT_COMMAND_MINIMUM_CREW = 6;
+        public const int DEFAULT_COMMAND_MINIMUM_CREW = 6;
         private readonly Vessel mVessel;
 
         public ProtoSignalProcessor(ProtoPartModuleSnapshot ppms, Vessel v)
@@ -26,7 +26,7 @@ namespace RemoteTech
             mVessel = v;
             Powered = ppms.GetBool("IsRTPowered");
 
-			int commandMinCrew = DEFAULT_COMMAND_MINIMUM_CREW;
+	    int commandMinCrew = DEFAULT_COMMAND_MINIMUM_CREW;
 			
             try {
                 commandMinCrew = ppms.GetInt("RTCommandMinCrew");
@@ -37,7 +37,7 @@ namespace RemoteTech
                 RTLog.Notify("ProtoSignalProcessor(Powered: {0}, HasCommandStation: {1}, Crew: {2}/6 [Default]", 
                     Powered, v.HasCommandStation(), v.GetVesselCrew().Count);
             }
-			IsCommandStation = Powered && v.HasCommandStation() && v.GetVesselCrew().Count >= commandMinCrew;
+            IsCommandStation = Powered && v.HasCommandStation() && v.GetVesselCrew().Count >= commandMinCrew;
         }
 
         public override String ToString()

--- a/src/RemoteTech/Modules/ProtoSignalProcessor.cs
+++ b/src/RemoteTech/Modules/ProtoSignalProcessor.cs
@@ -18,6 +18,7 @@ namespace RemoteTech
         public FlightComputer FlightComputer { get { return null; } }
         public bool IsMaster { get { return true; } }
 
+		public const int DEFAULT_COMMAND_MINIMUM_CREW = 6;
         private readonly Vessel mVessel;
 
         public ProtoSignalProcessor(ProtoPartModuleSnapshot ppms, Vessel v)
@@ -25,16 +26,18 @@ namespace RemoteTech
             mVessel = v;
             Powered = ppms.GetBool("IsRTPowered");
 
+			int commandMinCrew = DEFAULT_COMMAND_MINIMUM_CREW;
+			
             try {
-                IsCommandStation = Powered && v.HasCommandStation() && v.GetVesselCrew().Count >= ppms.GetInt("RTCommandMinCrew");
+                commandMinCrew = ppms.GetInt("RTCommandMinCrew");
                 RTLog.Notify("ProtoSignalProcessor(Powered: {0}, HasCommandStation: {1}, Crew: {2}/{3})", 
-                    Powered, v.HasCommandStation(), v.GetVesselCrew().Count, ppms.GetInt("RTCommandMinCrew"));
+                    Powered, v.HasCommandStation(), v.GetVesselCrew().Count, commandMinCrew));
             } catch (ArgumentException) {
                 // I'm assuming this would get thrown by ppms.GetInt()... do the other functions have an exception spec?
-                IsCommandStation = false;
-                RTLog.Notify("ProtoSignalProcessor(Powered: {0}, HasCommandStation: {1}, Crew: {2})", 
+                RTLog.Notify("ProtoSignalProcessor(Powered: {0}, HasCommandStation: {1}, Crew: {2}/6 [Default]", 
                     Powered, v.HasCommandStation(), v.GetVesselCrew().Count);
             }
+			IsCommandStation = Powered && v.HasCommandStation() && v.GetVesselCrew().Count >= commandMinCrew;
         }
 
         public override String ToString()

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -24,6 +24,7 @@ namespace RemoteTech
         [Persistent] public float ConsumptionMultiplier = 1.0f;
         [Persistent] public float RangeMultiplier = 1.0f;
         [Persistent] public String ActiveVesselGuid = "35b89a0d664c43c6bec8d0840afc97b2";
+		[Persistent] public int DefaultMinimumCrew = 6;
         [Persistent] public float SpeedOfLight = 3e8f;
         [Persistent] public MapFilter MapFilter = MapFilter.Path | MapFilter.Omni | MapFilter.Dish;
         [Persistent] public bool EnableSignalDelay = true;

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -24,7 +24,7 @@ namespace RemoteTech
         [Persistent] public float ConsumptionMultiplier = 1.0f;
         [Persistent] public float RangeMultiplier = 1.0f;
         [Persistent] public String ActiveVesselGuid = "35b89a0d664c43c6bec8d0840afc97b2";
-		[Persistent] public int DefaultMinimumCrew = 6;
+        [Persistent] public int DefaultMinimumCrew = 6;
         [Persistent] public float SpeedOfLight = 3e8f;
         [Persistent] public MapFilter MapFilter = MapFilter.Path | MapFilter.Omni | MapFilter.Dish;
         [Persistent] public bool EnableSignalDelay = true;


### PR DESCRIPTION
Instead of setting IsCommandStation to false when the RTCommandMinCrew errors out, default to 6 and note it in the log.