### PR TITLE
reconciles namespaces with where they are in the folder strucure

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -1,8 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using RemoteTech.RangeModel;
+using RemoteTech.SimpleTypes;
 
-namespace RemoteTech
+namespace RemoteTech.API
 {
     public static class API
     {

--- a/src/RemoteTech/AntennaManager.cs
+++ b/src/RemoteTech/AntennaManager.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using RemoteTech.Modules;
 
 
 namespace RemoteTech

--- a/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public abstract class AbstractCommand : ICommand
     {

--- a/src/RemoteTech/FlightComputer/Commands/ActionGroupCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ActionGroupCommand.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public class ActionGroupCommand : AbstractCommand
     {

--- a/src/RemoteTech/FlightComputer/Commands/AttitudeCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/AttitudeCommand.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public enum FlightMode
     {

--- a/src/RemoteTech/FlightComputer/Commands/BurnCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/BurnCommand.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public class BurnCommand : AbstractCommand
     {

--- a/src/RemoteTech/FlightComputer/Commands/CancelCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/CancelCommand.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public class CancelCommand : AbstractCommand
     {

--- a/src/RemoteTech/FlightComputer/Commands/ICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ICommand.cs
@@ -1,9 +1,6 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public interface ICommand : IComparable<ICommand>
     {

--- a/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
@@ -1,10 +1,8 @@
 using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public class ManeuverCommand : AbstractCommand
     {

--- a/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer.Commands
 {
     public class TargetCommand : AbstractCommand
     {

--- a/src/RemoteTech/FlightComputer/DelayedCommand.cs
+++ b/src/RemoteTech/FlightComputer/DelayedCommand.cs
@@ -1,8 +1,6 @@
 ﻿using System;
-using System.Text;
-using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer
 {
     public class DelayedFlightCtrlState : IComparable<DelayedFlightCtrlState>
     {

--- a/src/RemoteTech/FlightComputer/EventCommand.cs
+++ b/src/RemoteTech/FlightComputer/EventCommand.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using RemoteTech.FlightComputer.Commands;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer
 {
     public class EventCommand : AbstractCommand
     {

--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -1,11 +1,12 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using RemoteTech.FlightComputer.Commands;
+using RemoteTech.SimpleTypes;
+using RemoteTech.UI;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer
 {
     public class FlightComputer : IDisposable
     {
@@ -296,7 +297,7 @@ namespace RemoteTech
         public void updatePIDParameters()
         {
             if (Vessel != null) {
-                Vector3d torque = kOS.SteeringHelper.GetTorque (Vessel, 
+                Vector3d torque = SteeringHelper.GetTorque (Vessel, 
                     Vessel.ctrlState != null ? Vessel.ctrlState.mainThrottle : 0.0f);
                 var CoM = Vessel.findWorldCenterOfMass ();
                 var MoI = Vessel.findLocalMOI (CoM);

--- a/src/RemoteTech/FlightComputer/FlightCore.cs
+++ b/src/RemoteTech/FlightComputer/FlightCore.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
+using RemoteTech.FlightComputer.Commands;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer
 {
     public static class FlightCore
     {
@@ -27,7 +28,7 @@ namespace RemoteTech
                     up = (v.mainBody.position - v.CoM);
                     forward = Vector3.Exclude(up,
                         v.mainBody.position + v.mainBody.transform.up * (float)v.mainBody.Radius - v.CoM
-                     );
+                        );
                     break;
 
                 case ReferenceFrame.Maneuver:
@@ -109,7 +110,7 @@ namespace RemoteTech
         public static void HoldOrientation(FlightCtrlState fs, FlightComputer f, Quaternion target)
         {
             f.Vessel.ActionGroups.SetGroup(KSPActionGroup.SAS, false);
-            kOS.SteeringHelper.SteerShipToward(target, fs, f);
+            SteeringHelper.SteerShipToward(target, fs, f);
         }
 
         /// <summary>
@@ -165,10 +166,7 @@ namespace RemoteTech
             return thrust;
         }
     }
-}
 
-namespace kOS
-{
     public static class SteeringHelper
     {
         /// <summary>
@@ -177,7 +175,7 @@ namespace kOS
         /// <param name="target">The desired orientation</param>
         /// <param name="c">The FlightCtrlState for the current vessel.</param>
         /// <param name="fc">The flight computer carrying out the slew</param>
-        public static void SteerShipToward(Quaternion target, FlightCtrlState c, RemoteTech.FlightComputer fc)
+        public static void SteerShipToward(Quaternion target, FlightCtrlState c, FlightComputer fc)
         {
             // Add support for roll-less targets later -- Starstrider42
             bool fixedRoll = true;
@@ -218,7 +216,7 @@ namespace kOS
                         (delta.eulerAngles.z - 360.0F) :
                         delta.eulerAngles.z) * Math.PI / 180.0F
                     : 0F
-            );
+                );
 
             err += SwapYZ(spinMargin);
             err = new Vector3d(Math.Max(-Math.PI, Math.Min(Math.PI, err.x)),
@@ -388,7 +386,7 @@ namespace kOS
                         roll += reactionWheelModule.RollTorque;
                         yaw += reactionWheelModule.YawTorque;
                     }
-                    // Is there a more direct way to see if RCS is enabled? module.isEnabled doesn't work...
+                        // Is there a more direct way to see if RCS is enabled? module.isEnabled doesn't work...
                     else if (rcsModule != null && vessel.ActionGroups[KSPActionGroup.RCS])
                     {
                         var vesselTransform = vessel.GetTransform();
@@ -470,10 +468,10 @@ namespace kOS
         private static Vector3d ReduceAngles(Vector3d input)
         {
             return new Vector3d(
-                      (input.x > 180f) ? (input.x - 360f) : input.x,
-                      (input.y > 180f) ? (input.y - 360f) : input.y,
-                      (input.z > 180f) ? (input.z - 360f) : input.z
-                  );
+                (input.x > 180f) ? (input.x - 360f) : input.x,
+                (input.y > 180f) ? (input.y - 360f) : input.y,
+                (input.z > 180f) ? (input.z - 360f) : input.z
+                );
         }
 
         public static Vector3d Sign(Vector3d vector)

--- a/src/RemoteTech/FlightComputer/PIDControllerV2.cs
+++ b/src/RemoteTech/FlightComputer/PIDControllerV2.cs
@@ -7,12 +7,8 @@
 /// </description>
 
 using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer
 {
     // This PID Controler is used by Raf04 patch for the attitude controler. They have a separate implementation since they use
     // a different set of argument and do more (and less) than the other PID controler

--- a/src/RemoteTech/FlightComputer/UIPartActionMenuPatcher.cs
+++ b/src/RemoteTech/FlightComputer/UIPartActionMenuPatcher.cs
@@ -3,7 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
 
-namespace RemoteTech
+namespace RemoteTech.FlightComputer
 {
     public static class UIPartActionMenuPatcher
     {

--- a/src/RemoteTech/ISatellite.cs
+++ b/src/RemoteTech/ISatellite.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 
 namespace RemoteTech

--- a/src/RemoteTech/ISignalProcessor.cs
+++ b/src/RemoteTech/ISignalProcessor.cs
@@ -18,7 +18,7 @@ namespace RemoteTech
         bool IsMaster { get; }
 
         // Reserved for Flight Computer
-        FlightComputer FlightComputer { get; }
+        FlightComputer.FlightComputer FlightComputer { get; }
         Vessel Vessel { get; }
     }
 }

--- a/src/RemoteTech/Modules/MissionControlAntenna.cs
+++ b/src/RemoteTech/Modules/MissionControlAntenna.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Linq;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     public sealed class MissionControlAntenna : IAntenna
     {

--- a/src/RemoteTech/Modules/ModuleRTAntenna.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntenna.cs
@@ -2,11 +2,12 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using System.Reflection;
+using System.Text;
+using RemoteTech.UI;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     [KSPModule("Antenna")]
     public class ModuleRTAntenna : PartModule, IAntenna

--- a/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
@@ -5,7 +5,7 @@ using System.Linq;
 using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     [KSPModule("Technology Perk")]
     public class ModuleRTAntennaPassive : PartModule, IAntenna

--- a/src/RemoteTech/Modules/ModuleRTDataTransmitter.cs
+++ b/src/RemoteTech/Modules/ModuleRTDataTransmitter.cs
@@ -2,10 +2,9 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     public sealed class ModuleRTDataTransmitter : PartModule, IScienceDataTransmitter
     {

--- a/src/RemoteTech/Modules/ModuleSPU.cs
+++ b/src/RemoteTech/Modules/ModuleSPU.cs
@@ -1,9 +1,10 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using RemoteTech.FlightComputer;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     [KSPModule("Signal Processor")]
     public class ModuleSPU : PartModule, ISignalProcessor
@@ -23,7 +24,7 @@ namespace RemoteTech
                 return IsRTPowered && IsRTCommandStation && vessel.GetVesselCrew().Count >= RTCommandMinCrew;
             }
         }
-        public FlightComputer FlightComputer { get; private set; }
+        public FlightComputer.FlightComputer FlightComputer { get; private set; }
         public Vessel Vessel { get { return vessel; } }
         public bool IsMaster { get { return Satellite != null && Satellite.SignalProcessor == this; } }
 
@@ -79,7 +80,7 @@ namespace RemoteTech
                 mRegisteredId = vessel.id; 
                 RTCore.Instance.Satellites.Register(vessel, this);
                 if (FlightComputer == null)
-                    FlightComputer = new FlightComputer(this);
+                    FlightComputer = new FlightComputer.FlightComputer(this);
             }
             Fields["GUI_Status"].guiActive = ShowGUI_Status;
         }
@@ -205,7 +206,7 @@ namespace RemoteTech
                 if (HighLogic.fetch && HighLogic.LoadedSceneIsFlight)
                 {
                     if (FlightComputer == null)
-                        FlightComputer = new FlightComputer(this);
+                        FlightComputer = new FlightComputer.FlightComputer(this);
                     FlightComputer.Save(node);
                 }
 
@@ -220,7 +221,7 @@ namespace RemoteTech
                 if (HighLogic.fetch && HighLogic.LoadedSceneIsFlight)
                 {
                     if (FlightComputer == null)
-                        FlightComputer = new FlightComputer(this);
+                        FlightComputer = new FlightComputer.FlightComputer(this);
                     FlightComputer.load(node);
                 }
             }

--- a/src/RemoteTech/Modules/ModuleSPUPassive.cs
+++ b/src/RemoteTech/Modules/ModuleSPUPassive.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     public class ModuleSPUPassive : PartModule, ISignalProcessor
     {
@@ -16,7 +14,7 @@ namespace RemoteTech
         public bool Visible { get { return MapViewFiltering.CheckAgainstFilter(vessel); } }
         public bool Powered { get { return Vessel.IsControllable; } }
         public bool IsCommandStation { get { return false; } }
-        public FlightComputer FlightComputer { get { return null; } }
+        public FlightComputer.FlightComputer FlightComputer { get { return null; } }
         public Vessel Vessel { get { return vessel; } }
         public bool IsMaster { get { return false; } }
 

--- a/src/RemoteTech/Modules/ProtoAntenna.cs
+++ b/src/RemoteTech/Modules/ProtoAntenna.cs
@@ -1,7 +1,6 @@
 ﻿using System;
-using System.Linq;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     internal class ProtoAntenna : IAntenna
     {

--- a/src/RemoteTech/Modules/ProtoSignalProcessor.cs
+++ b/src/RemoteTech/Modules/ProtoSignalProcessor.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.Modules
 {
     public class ProtoSignalProcessor : ISignalProcessor
     {
@@ -15,7 +15,7 @@ namespace RemoteTech
         public bool IsCommandStation { get; private set; }
         public Guid Guid { get { return mVessel.id; } }
         public Vessel Vessel { get { return mVessel; } }
-        public FlightComputer FlightComputer { get { return null; } }
+        public FlightComputer.FlightComputer FlightComputer { get { return null; } }
         public bool IsMaster { get { return true; } }
 
         private readonly Vessel mVessel;

--- a/src/RemoteTech/NetworkFeedback.cs
+++ b/src/RemoteTech/NetworkFeedback.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using RemoteTech.RangeModel;
 
 namespace RemoteTech
 {

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -2,18 +2,13 @@
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
+using RemoteTech.Modules;
+using RemoteTech.RangeModel;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 
 namespace RemoteTech
 {
-    [Flags]
-    public enum RangeModel
-    {
-        Standard,
-        Additive,
-        Root = Additive,
-    }
-
     public partial class NetworkManager : IEnumerable<ISatellite>
     {
         public event Action<ISatellite, NetworkLink<ISatellite>> OnLinkAdd = delegate { };
@@ -144,7 +139,7 @@ namespace RemoteTech
 
             switch (RTSettings.Instance.RangeModelType)
             {
-                case RangeModel.Additive: // NathanKell
+                case RangeModel.RangeModel.Additive: // NathanKell
                     return RangeModelRoot.GetLink(sat_a, sat_b);
                 default: // Stock range model
                     return RangeModelStandard.GetLink(sat_a, sat_b);

--- a/src/RemoteTech/NetworkPathfinder.cs
+++ b/src/RemoteTech/NetworkPathfinder.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using RemoteTech.SimpleTypes;
 
 namespace RemoteTech
 {

--- a/src/RemoteTech/NetworkRenderer.cs
+++ b/src/RemoteTech/NetworkRenderer.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using RemoteTech.SimpleTypes;
+using RemoteTech.UI;
 using UnityEngine;
 using Debug = System.Diagnostics.Debug;
 

--- a/src/RemoteTech/RTCore.cs
+++ b/src/RemoteTech/RTCore.cs
@@ -1,6 +1,8 @@
 ﻿using System;
 using System.Linq;
 using System.Collections.Generic;
+using RemoteTech.FlightComputer.Commands;
+using RemoteTech.UI;
 using UnityEngine;
 
 namespace RemoteTech

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -28,7 +28,7 @@ namespace RemoteTech
         [Persistent] public float SpeedOfLight = 3e8f;
         [Persistent] public MapFilter MapFilter = MapFilter.Path | MapFilter.Omni | MapFilter.Dish;
         [Persistent] public bool EnableSignalDelay = true;
-        [Persistent] public RangeModel RangeModelType = RangeModel.Standard;
+        [Persistent] public RangeModel.RangeModel RangeModelType = RangeModel.RangeModel.Standard;
         [Persistent] public double MultipleAntennaMultiplier = 0.0;
         [Persistent] public bool ThrottleTimeWarp = true;
         [Persistent] public bool HideGroundStationsBehindBody = false;

--- a/src/RemoteTech/RTUtil.cs
+++ b/src/RemoteTech/RTUtil.cs
@@ -8,6 +8,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 using Object = System.Object;
 using Debug = UnityEngine.Debug;

--- a/src/RemoteTech/RangeModel/AbstractRangeModel.cs
+++ b/src/RemoteTech/RangeModel/AbstractRangeModel.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using RemoteTech.SimpleTypes;
 
-namespace RemoteTech
+namespace RemoteTech.RangeModel
 {
     public static class AbstractRangeModel
     {

--- a/src/RemoteTech/RangeModel/RangeModel.cs
+++ b/src/RemoteTech/RangeModel/RangeModel.cs
@@ -1,0 +1,12 @@
+﻿using System;
+
+namespace RemoteTech.RangeModel
+{
+    [Flags]
+    public enum RangeModel
+    {
+        Standard,
+        Additive,
+        Root = Additive,
+    }
+}

--- a/src/RemoteTech/RangeModel/RangeModelExtensions.cs
+++ b/src/RemoteTech/RangeModel/RangeModelExtensions.cs
@@ -1,6 +1,7 @@
 ﻿using System;
+using RemoteTech.SimpleTypes;
 
-namespace RemoteTech
+namespace RemoteTech.RangeModel
 {
     public static class RangeModelExtensions
     {

--- a/src/RemoteTech/RangeModel/RangeModelRoot.cs
+++ b/src/RemoteTech/RangeModel/RangeModelRoot.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using RemoteTech.SimpleTypes;
 
-namespace RemoteTech
+namespace RemoteTech.RangeModel
 {
     public static class RangeModelRoot
     {

--- a/src/RemoteTech/RangeModel/RangeModelStandard.cs
+++ b/src/RemoteTech/RangeModel/RangeModelStandard.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+using RemoteTech.SimpleTypes;
 
-namespace RemoteTech
+namespace RemoteTech.RangeModel
 {
     public static class RangeModelStandard
     {

--- a/src/RemoteTech/SatelliteManager.cs
+++ b/src/RemoteTech/SatelliteManager.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using RemoteTech.Modules;
 
 namespace RemoteTech
 {

--- a/src/RemoteTech/SimpleTypes/BidirectionalEdge.cs
+++ b/src/RemoteTech/SimpleTypes/BidirectionalEdge.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     public enum LinkType
     {

--- a/src/RemoteTech/SimpleTypes/BinaryHeap.cs
+++ b/src/RemoteTech/SimpleTypes/BinaryHeap.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     // Sadly there is no way to enforce immutability C#.
     // Do not modify sorting order externally! Increase/Decrease().

--- a/src/RemoteTech/SimpleTypes/CachedField.cs
+++ b/src/RemoteTech/SimpleTypes/CachedField.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace RemoteTech
+﻿namespace RemoteTech.SimpleTypes
 {
     public struct CachedField<T>
     {

--- a/src/RemoteTech/SimpleTypes/Dish.cs
+++ b/src/RemoteTech/SimpleTypes/Dish.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     public class Dish
     {

--- a/src/RemoteTech/SimpleTypes/GUITextureButtonFactory.cs
+++ b/src/RemoteTech/SimpleTypes/GUITextureButtonFactory.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     public static class GUITextureButtonFactory
     {

--- a/src/RemoteTech/SimpleTypes/NetworkLink.cs
+++ b/src/RemoteTech/SimpleTypes/NetworkLink.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     public class NetworkLink<T> : IEquatable<NetworkLink<T>>
     {

--- a/src/RemoteTech/SimpleTypes/NetworkRoute.cs
+++ b/src/RemoteTech/SimpleTypes/NetworkRoute.cs
@@ -1,9 +1,8 @@
 ﻿using System;
-using System.Text;
-using System.Linq;
 using System.Collections.Generic;
+using System.Linq;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     public class NetworkRoute<T> : IComparable<NetworkRoute<T>>
     {

--- a/src/RemoteTech/SimpleTypes/PriorityQueue.cs
+++ b/src/RemoteTech/SimpleTypes/PriorityQueue.cs
@@ -1,8 +1,7 @@
-﻿using System;
-using System.Collections;
+﻿using System.Collections;
 using System.Collections.Generic;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     // PriorityQueue based on a minimum-BinaryHeap.
     public class PriorityQueue<T> : IEnumerable<T>

--- a/src/RemoteTech/SimpleTypes/TimeStringConverter.cs
+++ b/src/RemoteTech/SimpleTypes/TimeStringConverter.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
 using System.Text;
 using System.Text.RegularExpressions;
 
-namespace RemoteTech
+namespace RemoteTech.SimpleTypes
 {
     /// <summary>
     /// This class converts time strings like "1d 2m 2s" into a

--- a/src/RemoteTech/UI/AbstractWindow.cs
+++ b/src/RemoteTech/UI/AbstractWindow.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public enum WindowAlign
     {

--- a/src/RemoteTech/UI/AntennaFragment.cs
+++ b/src/RemoteTech/UI/AntennaFragment.cs
@@ -1,10 +1,8 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class AntennaFragment : IFragment, IDisposable
     {

--- a/src/RemoteTech/UI/AntennaWindow.cs
+++ b/src/RemoteTech/UI/AntennaWindow.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class AntennaWindow : AbstractWindow
     {

--- a/src/RemoteTech/UI/AttitudeFragment.cs
+++ b/src/RemoteTech/UI/AttitudeFragment.cs
@@ -1,7 +1,8 @@
 ﻿using System;
+using RemoteTech.FlightComputer.Commands;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public enum ComputerMode
     {
@@ -81,7 +82,7 @@ namespace RemoteTech
 
         private FlightAttitude Attitude { get { return mAttitude; } }
 
-        private FlightComputer mFlightComputer;
+        private FlightComputer.FlightComputer mFlightComputer;
         private Action mOnClickQueue;
 
         private ComputerMode mMode;
@@ -93,7 +94,7 @@ namespace RemoteTech
         private String mHeading = "90";
         private String mDuration = "0s";
 
-        public AttitudeFragment(FlightComputer fc, Action queue)
+        public AttitudeFragment(FlightComputer.FlightComputer fc, Action queue)
         {
             mFlightComputer = fc;
             mOnClickQueue = queue;

--- a/src/RemoteTech/UI/EZGUIPointerDisablePatcher.cs
+++ b/src/RemoteTech/UI/EZGUIPointerDisablePatcher.cs
@@ -2,7 +2,7 @@
 using System.Reflection;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
 
     public class EZGUIPointerDisablePatcher : IDisposable

--- a/src/RemoteTech/UI/FilterOverlay.cs
+++ b/src/RemoteTech/UI/FilterOverlay.cs
@@ -1,8 +1,9 @@
 ﻿using System;
 using System.Linq;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class FilterOverlay : IFragment, IDisposable
     {

--- a/src/RemoteTech/UI/FlightComputerWindow.cs
+++ b/src/RemoteTech/UI/FlightComputerWindow.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class FlightComputerWindow : AbstractWindow
     {
@@ -12,7 +9,7 @@ namespace RemoteTech
         private readonly QueueFragment mQueue;
         private bool mQueueEnabled;
 
-        public FlightComputerWindow(FlightComputer fc)
+        public FlightComputerWindow(FlightComputer.FlightComputer fc)
             : base(Guid.NewGuid(), "Flight Computer", new Rect(100, 100, 0, 0), WindowAlign.Floating)
         {
             mSavePosition = true;

--- a/src/RemoteTech/UI/FlightUIPatcher.cs
+++ b/src/RemoteTech/UI/FlightUIPatcher.cs
@@ -1,9 +1,6 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using RemoteTech.FlightComputer.Commands;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class FlightUIPatcher
     {

--- a/src/RemoteTech/UI/FocusFragment.cs
+++ b/src/RemoteTech/UI/FocusFragment.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class FocusFragment : IFragment
     {

--- a/src/RemoteTech/UI/FocusOverlay.cs
+++ b/src/RemoteTech/UI/FocusOverlay.cs
@@ -1,8 +1,8 @@
 ﻿using System;
-using System.Linq;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class FocusOverlay : IFragment, IDisposable
     {

--- a/src/RemoteTech/UI/IFragment.cs
+++ b/src/RemoteTech/UI/IFragment.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
-
-namespace RemoteTech
+﻿namespace RemoteTech.UI
 {
     interface IFragment
     {

--- a/src/RemoteTech/UI/NetworkCone.cs
+++ b/src/RemoteTech/UI/NetworkCone.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class NetworkCone : MonoBehaviour
     {

--- a/src/RemoteTech/UI/NetworkLine.cs
+++ b/src/RemoteTech/UI/NetworkLine.cs
@@ -1,10 +1,8 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
+﻿using System.Linq;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class NetworkLine : MonoBehaviour
     {

--- a/src/RemoteTech/UI/QueueFragment.cs
+++ b/src/RemoteTech/UI/QueueFragment.cs
@@ -1,15 +1,15 @@
 ﻿using System;
-using System.Text;
-using System.Linq;
 using System.Collections;
 using System.Collections.Generic;
+using System.Text;
+using RemoteTech.FlightComputer.Commands;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class QueueFragment : IFragment
     {
-        private readonly FlightComputer mFlightComputer;
+        private readonly FlightComputer.FlightComputer mFlightComputer;
 
         private Vector2 mScrollPosition;
         private String mExtraDelay;
@@ -26,28 +26,28 @@ namespace RemoteTech
             {
                 var tooltip = new List<String>();
                 var status = new List<String>();
-                if ((mFlightComputer.Status & FlightComputer.State.NoConnection) == FlightComputer.State.NoConnection)
+                if ((mFlightComputer.Status & FlightComputer.FlightComputer.State.NoConnection) == FlightComputer.FlightComputer.State.NoConnection)
                 {
                     status.Add("Connection Error");
                     tooltip.Add("Cannot queue commands");
                 }
-                if ((mFlightComputer.Status & FlightComputer.State.OutOfPower) == FlightComputer.State.OutOfPower)
+                if ((mFlightComputer.Status & FlightComputer.FlightComputer.State.OutOfPower) == FlightComputer.FlightComputer.State.OutOfPower)
                 {
                     status.Add("Out of Power");
                     tooltip.Add("Commands can be missed");
                     tooltip.Add("Timers halt");
                 }
-                if ((mFlightComputer.Status & FlightComputer.State.NotMaster) == FlightComputer.State.NotMaster)
+                if ((mFlightComputer.Status & FlightComputer.FlightComputer.State.NotMaster) == FlightComputer.FlightComputer.State.NotMaster)
                 {
                     status.Add("Slave");
                     tooltip.Add("Has no control");
                 }
-                if ((mFlightComputer.Status & FlightComputer.State.Packed) == FlightComputer.State.Packed)
+                if ((mFlightComputer.Status & FlightComputer.FlightComputer.State.Packed) == FlightComputer.FlightComputer.State.Packed)
                 {
                     status.Add("Packed");
                     tooltip.Add("Frozen");
                 }
-                if (mFlightComputer.Status == FlightComputer.State.Normal)
+                if (mFlightComputer.Status == FlightComputer.FlightComputer.State.Normal)
                 {
                     status.Add("All systems nominal");
                     tooltip.Add("None");
@@ -57,7 +57,7 @@ namespace RemoteTech
             }
         }
 
-        public QueueFragment(FlightComputer fc)
+        public QueueFragment(FlightComputer.FlightComputer fc)
         {
             mFlightComputer = fc;
             Delay = 0;

--- a/src/RemoteTech/UI/SatelliteFragment.cs
+++ b/src/RemoteTech/UI/SatelliteFragment.cs
@@ -1,10 +1,8 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class SatelliteFragment : IFragment, IDisposable
     {

--- a/src/RemoteTech/UI/TargetInfoFragment.cs
+++ b/src/RemoteTech/UI/TargetInfoFragment.cs
@@ -1,10 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     class TargetInfoFragment : IFragment, IDisposable
     {

--- a/src/RemoteTech/UI/TargetInfoWindow.cs
+++ b/src/RemoteTech/UI/TargetInfoWindow.cs
@@ -1,10 +1,7 @@
 ﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class TargetInfoWindow : AbstractWindow
     {

--- a/src/RemoteTech/UI/TimeWarpDecorator.cs
+++ b/src/RemoteTech/UI/TimeWarpDecorator.cs
@@ -1,10 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 
-namespace RemoteTech
+namespace RemoteTech.UI
 {
     public class TimeWarpDecorator
     {

--- a/src/RemoteTech/VesselSatellite.cs
+++ b/src/RemoteTech/VesselSatellite.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
+using RemoteTech.SimpleTypes;
 using UnityEngine;
 
 namespace RemoteTech
@@ -74,7 +75,7 @@ namespace RemoteTech
             get { return RTCore.Instance.Antennas[this]; }
         }
 
-        public FlightComputer FlightComputer { 
+        public FlightComputer.FlightComputer FlightComputer { 
             get { return SignalProcessor.FlightComputer; } 
         }
 


### PR DESCRIPTION
This is a lot of smoke with very little fire. All it does is change the namespaces when they did not match their place in the folder structure.

The RangeModel enum needed to move into the rangemodel namespace because you cant have an enum and a namespace at the same level.