### PR TITLE
Keep keystrokes on inputs

### DIFF
--- a/src/RemoteTech/UI/AbstractWindow.cs
+++ b/src/RemoteTech/UI/AbstractWindow.cs
@@ -95,6 +95,7 @@ namespace RemoteTech
 
         public virtual void Hide()
         {
+            removeWindowCtrlLock();
             Windows.Remove(mGuid);
             Enabled = false;
             if (mSavePosition)
@@ -187,6 +188,16 @@ namespace RemoteTech
                     onPositionChanged.Invoke();
                     backupPosition = Position;
                 }
+
+                // Set ship control lock if one rt input is in focus
+                if (GUI.GetNameOfFocusedControl().StartsWith("rt_"))
+                {
+                    setWindowCtrlLock();
+                }
+                else
+                {
+                    removeWindowCtrlLock();
+                }
             }
         }
 
@@ -194,6 +205,27 @@ namespace RemoteTech
         {
             RTSettings.Instance.savedWindowPositions.Remove(this.GetType().ToString());
             RTSettings.Instance.savedWindowPositions.Add(this.GetType().ToString(), Position);
+        }
+
+        /// <summary>
+        /// Set a input lock to keep typing to this window
+        /// </summary>
+        public void setWindowCtrlLock()
+        {
+            // only if we are enabled
+            if (Enabled)
+            {
+                InputLockManager.SetControlLock(ControlTypes.ALL_SHIP_CONTROLS, "RTLockControlForWindows");
+            }
+        }
+
+
+        /// <summary>
+        /// Remove the input lock
+        /// </summary>
+        public void removeWindowCtrlLock()
+        {
+            InputLockManager.RemoveControlLock("RTLockControlForWindows");
         }
     }
 }

--- a/src/RemoteTech/UI/AttitudeFragment.cs
+++ b/src/RemoteTech/UI/AttitudeFragment.cs
@@ -106,7 +106,7 @@ namespace RemoteTech
             float width3 = 156 / 3 - GUI.skin.button.margin.right * 2.0f / 3.0f;
             if (Event.current.Equals(Event.KeyboardEvent("return")))
             {
-                if (GUI.GetNameOfFocusedControl().StartsWith("phr"))
+                if (GUI.GetNameOfFocusedControl().StartsWith("rt_phr"))
                 {
                     mPitch = Pitch.ToString();
                     mHeading = Heading.ToString();
@@ -117,7 +117,7 @@ namespace RemoteTech
                         Confirm();
                     }
                 }
-                else if (GUI.GetNameOfFocusedControl() == "burn")
+                else if (GUI.GetNameOfFocusedControl() == "rt_burn")
                 {
                     OnBurnClick();
                 }
@@ -163,7 +163,7 @@ namespace RemoteTech
                     GUILayout.Label(new GUIContent("PIT:", "Sets pitch."), GUILayout.Width(width3));
                     RTUtil.Button("+", () => Pitch++);
                     RTUtil.Button("-", () => Pitch--);
-                    GUI.SetNextControlName("phr1");
+                    GUI.SetNextControlName("rt_phr1");
                     RTUtil.TextField(ref mPitch, GUILayout.Width(width3));
                 }
                 GUILayout.EndHorizontal();
@@ -173,7 +173,7 @@ namespace RemoteTech
                     GUILayout.Label(new GUIContent("HDG:", "Sets heading."), GUILayout.Width(width3));
                     RTUtil.Button("+", () => Heading++);
                     RTUtil.Button("-", () => Heading--);
-                    GUI.SetNextControlName("phr2");
+                    GUI.SetNextControlName("rt_phr2");
                     RTUtil.TextField(ref mHeading, GUILayout.Width(width3));
                 }
                 GUILayout.EndHorizontal();
@@ -183,7 +183,7 @@ namespace RemoteTech
                     GUILayout.Label(new GUIContent("RLL:", "Sets roll."), GUILayout.Width(width3));
                     RTUtil.Button("+", () => Roll++);
                     RTUtil.Button("-", () => Roll--);
-                    GUI.SetNextControlName("phr3");
+                    GUI.SetNextControlName("rt_phr3");
                     RTUtil.TextField(ref mRoll, GUILayout.Width(width3));
                 }
                 GUILayout.EndHorizontal();
@@ -197,7 +197,7 @@ namespace RemoteTech
                 GUILayout.EndHorizontal();
 
                 RTUtil.HorizontalSlider(ref mThrottle, 0, 1);
-                GUI.SetNextControlName("burn");
+                GUI.SetNextControlName("rt_burn");
                 RTUtil.TextField(ref mDuration);
 
                 GUILayout.BeginHorizontal();

--- a/src/RemoteTech/UI/QueueFragment.cs
+++ b/src/RemoteTech/UI/QueueFragment.cs
@@ -65,7 +65,7 @@ namespace RemoteTech
 
         public void Draw()
         {
-            if (Event.current.Equals(Event.KeyboardEvent("return")) && GUI.GetNameOfFocusedControl() == "xd")
+            if (Event.current.Equals(Event.KeyboardEvent("return")) && GUI.GetNameOfFocusedControl() == "rt_xd")
             {
                 RTCore.Instance.StartCoroutine(onClickAddExtraDelay());
             }
@@ -111,7 +111,7 @@ namespace RemoteTech
                 {
                     GUILayout.Label(new GUIContent("Delay (+ signal): " + RTUtil.FormatDuration(mFlightComputer.TotalDelay), "Total delay including signal delay."));
                     GUILayout.FlexibleSpace();
-                    GUI.SetNextControlName("xd");
+                    GUI.SetNextControlName("rt_xd");
                     RTUtil.TextField(ref mExtraDelay, GUILayout.Width(45));
                     RTUtil.Button(new GUIContent(">", "Add extra signal delay - Example: 125, 125s, 5m20s, 1d6h20m10s"), () => RTCore.Instance.StartCoroutine(onClickAddExtraDelay()), GUILayout.Width(21), GUILayout.Height(21));
                 }


### PR DESCRIPTION
- renamed all remotetech inputs with a small prefix 'rt_'
- added two new methods to the AbstractWindow to handle a stacklock for focused remotetech inputs

Fixes #197 