### PR TITLE
Fix for the correct ExtraDelay after switching

### DIFF
--- a/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
@@ -51,6 +51,13 @@ namespace RemoteTech.FlightComputer.Commands
             }
             catch (Exception) {}
 
+            if (Delay == 0) {
+                // only save the current gametime if we have no signal delay.
+                // We need this to calculate the correct delta time for the
+                // ExtraDelay if we come back to this satellite.
+                TimeStamp = RTUtil.GameTime;
+            }
+
             save.AddValue("TimeStamp", TimeStamp);
             save.AddValue("ExtraDelay", ExtraDelay);
             n.AddNode(save);

--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -353,7 +353,7 @@ namespace RemoteTech.FlightComputer
         /// <param name="n">Node with the informations for the flightcomputer</param>
         public void load(ConfigNode n)
         {
-            RTLog.Notify("Loading Flightcomputer from persistant!");
+            RTLog.Notify("Loading Flightcomputer from persistent!");
 
             if (!n.HasNode("FlightComputer"))
                 return;
@@ -402,7 +402,7 @@ namespace RemoteTech.FlightComputer
                 if (mCommandQueue.Count > 0)
                     mCommandQueue.Clear();
 
-                RTLog.Notify("Loading queued commands from persistant ...");
+                RTLog.Notify("Loading queued commands from persistent ...");
                 foreach (ConfigNode cmdNode in Commands.nodes)
                 {
                     ICommand cmd = AbstractCommand.LoadCommand(cmdNode, this);
@@ -424,7 +424,6 @@ namespace RemoteTech.FlightComputer
                             if (cmd.ExtraDelay > 0)
                             {
                                 cmd.ExtraDelay = cmd.TimeStamp  + cmd.ExtraDelay - RTUtil.GameTime;
-                                cmd.TimeStamp = RTUtil.GameTime;
 
                                 // Are we ready to handle the command ?
                                 if (cmd.ExtraDelay <= 0)


### PR DESCRIPTION
The `Timestamp` will now be changed by saving the command instead of loading

Resolves #299 