### PR TITLE
Disappeared sat fragment

### DIFF
--- a/src/RemoteTech/UI/FocusOverlay.cs
+++ b/src/RemoteTech/UI/FocusOverlay.cs
@@ -28,7 +28,7 @@ namespace RemoteTech.UI
 
         private FocusFragment mFocus = new FocusFragment();
         private bool mEnabled;
-        private bool mShowOverlay;
+        private bool mShowOverlay = true;
 
         private Rect PositionButton
         {


### PR DESCRIPTION
The `mShowOverlay` flag isn't initialized. This is the cause why the satellite fragment is not displayed properly