### PR TITLE
Changed TakeWhile to Where

### DIFF
--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -233,7 +233,8 @@ namespace RemoteTech.FlightComputer
                     }
                 }
 
-                foreach (var dc in mCommandQueue.TakeWhile(c => c.TimeStamp <= RTUtil.GameTime).ToList())
+                // Proceed the extraDelay for every command where the normal delay is over
+                foreach (var dc in mCommandQueue.Where(s=>s.Delay==0).ToList())
                 {
                     // Use time decrement instead of comparing scheduled time, in case we later want to 
                     //      reinstate event clocks stopping under certain conditions


### PR DESCRIPTION
After rerange the list, some of the items where the condition are also true, will not returned because thay are behind the first fail of the condition (`` c.TimeStamp <= RTUtil.GameTime ``)

Edit: Fixes #305 