### PR TITLE
Target command fix

### DIFF
--- a/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
@@ -27,8 +27,12 @@ namespace RemoteTech.FlightComputer.Commands
         {
             f.DelayedTarget = Target;
             f.lastTarget = this;
-            // Switch the vessels target
-            FlightGlobals.fetch.SetVesselTarget(Target);
+
+            if (Target != null && Target != FlightGlobals.fetch.VesselTarget)
+            {
+                // Switch the vessels target
+                FlightGlobals.fetch.SetVesselTarget(Target);
+            }
 
             return true;
         }
@@ -87,26 +91,29 @@ namespace RemoteTech.FlightComputer.Commands
         public override void Save(ConfigNode n, FlightComputer fc)
         {
             if (Target != null)
+            {
                 TargetType = Target.GetType().ToString();
 
-            switch (TargetType)
-            {
-                case "Vessel":
-                    {
-                        TargetId = ((Vessel)Target).id.ToString();
-                        break;
-                    }
-                case "CelestialBody":
-                    {
-                        TargetId = FlightGlobals.Bodies.ToList().IndexOf(((CelestialBody)Target)).ToString();
-                        break;
-                    }
-                default:
-                    {
-                        TargetId = null;
-                        break;
-                    }
+                switch (TargetType)
+                {
+                    case "Vessel":
+                        {
+                            TargetId = ((Vessel)Target).id.ToString();
+                            break;
+                        }
+                    case "CelestialBody":
+                        {
+                            TargetId = FlightGlobals.Bodies.ToList().IndexOf(((CelestialBody)Target)).ToString();
+                            break;
+                        }
+                    default:
+                        {
+                            TargetId = null;
+                            break;
+                        }
+                }
             }
+
             base.Save(n, fc);
         }
     }


### PR DESCRIPTION
We got some really weird issues when we save a "none" target, or by loading a target thats already the target of the satellite. This can run into a complete failure of the ksp ui.

This pr can fix #311 , fix #313 and even fix #312