### PR TITLE
Add External Mod access

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -93,28 +93,36 @@ namespace RemoteTech.API
         }
         public static void ReceiveData(ConfigNode ExternalData) //exposed method called by other mods, passing a ConfigNode to RemoteTech
         {
-
-            RemoteTech.FlightComputer.Commands.ExternalAPICommand extCmd = new RemoteTech.FlightComputer.Commands.ExternalAPICommand() //make our command
+            if (ExternalData != null) //check we were actually passed a config node
             {
-                externalData = ExternalData,
-                TimeStamp = RTUtil.GameTime,
-                description = ExternalData.GetValue("Description"),
-                shortName = ExternalData.GetValue("ShortName"),
-                reflectionGetType = ExternalData.GetValue("ReflectionGetType"),
-                reflectionInvokeMember = ExternalData.GetValue("ReflectionInvokeMember"),
-                vslGUIDstr = ExternalData.GetValue("GUIDString"),
-            };
-            foreach (Vessel vsl2 in FlightGlobals.Vessels) //can not find a Guid.Parse method, so do it this way
-            {
-                if (vsl2.id.ToString() == extCmd.vslGUIDstr)
+                try
                 {
-                    extCmd.vslGUID = vsl2.id;
-                    extCmd.vsl = vsl2;
+                    RemoteTech.FlightComputer.Commands.ExternalAPICommand extCmd = new RemoteTech.FlightComputer.Commands.ExternalAPICommand() //make our command
+                    {
+                        externalData = ExternalData,
+                        TimeStamp = RTUtil.GameTime,
+                        description = ExternalData.GetValue("Description"), //string on GUI
+                        shortName = ExternalData.GetValue("ShortName"), //???
+                        reflectionGetType = ExternalData.GetValue("ReflectionGetType"), //required for reflection back
+                        reflectionInvokeMember = ExternalData.GetValue("ReflectionInvokeMember"), //required 
+                        vslGUIDstr = ExternalData.GetValue("GUIDString"),
+                    };
+                    foreach (Vessel vsl2 in FlightGlobals.Vessels) //can not find a Guid.Parse method, so do it this way
+                    {
+                        if (vsl2.id.ToString() == extCmd.vslGUIDstr)
+                        {
+                            extCmd.vslGUID = vsl2.id;
+                            extCmd.vsl = vsl2;
+                        }
+                    }
+                    RemoteTech.FlightComputer.FlightComputer fltComp = RTCore.Instance.Satellites[extCmd.vslGUID].FlightComputer;
+                    fltComp.Enqueue(extCmd);
+                }
+                catch
+                {
+                    RTDebugUnit.print("RT Error: Invalid ConfigNode passed by other mod");
                 }
             }
-            RemoteTech.FlightComputer.FlightComputer fltComp = RTCore.Instance.Satellites[extCmd.vslGUID].FlightComputer;
-
-            fltComp.Enqueue(extCmd);
         }
     }
 }

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -91,5 +91,30 @@ namespace RemoteTech.API
             RTLog.Verbose("Connection from {0} to {1} Delay: {2}", a, b, delayBetween);
             return delayBetween;
         }
+        public static void ReceiveData(ConfigNode ExternalData) //exposed method called by other mods, passing a ConfigNode to RemoteTech
+        {
+
+            RemoteTech.FlightComputer.Commands.ExternalAPICommand extCmd = new RemoteTech.FlightComputer.Commands.ExternalAPICommand() //make our command
+            {
+                externalData = ExternalData,
+                TimeStamp = RTUtil.GameTime,
+                description = ExternalData.GetValue("Description"),
+                shortName = ExternalData.GetValue("ShortName"),
+                reflectionGetType = ExternalData.GetValue("ReflectionGetType"),
+                reflectionInvokeMember = ExternalData.GetValue("ReflectionInvokeMember"),
+                vslGUIDstr = ExternalData.GetValue("GUIDString"),
+            };
+            foreach (Vessel vsl2 in FlightGlobals.Vessels) //can not find a Guid.Parse method, so do it this way
+            {
+                if (vsl2.id.ToString() == extCmd.vslGUIDstr)
+                {
+                    extCmd.vslGUID = vsl2.id;
+                    extCmd.vsl = vsl2;
+                }
+            }
+            RemoteTech.FlightComputer.FlightComputer fltComp = RTCore.Instance.Satellites[extCmd.vslGUID].FlightComputer;
+
+            fltComp.Enqueue(extCmd);
+        }
     }
 }

--- a/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
@@ -102,6 +102,7 @@ namespace RemoteTech.FlightComputer.Commands
                 case "TargetCommand":       { command = new TargetCommand(); break; }
                 case "EventCommand":        { command = new EventCommand(); break; }
                 case "DriveCommand":        { command = new DriveCommand(); break; }
+                case "ExternalAPICommand":  { command = new ExternalAPICommand(); break; }
             }
 
             if (command != null)

--- a/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
@@ -17,7 +17,7 @@ namespace RemoteTech.FlightComputer.Commands
 
         public override string Description
         {
-            get { return description; }
+            get { return description + Environment.NewLine + base.Description; }
         }
         public override string ShortName { get { return shortName; } }
 

--- a/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
@@ -1,0 +1,41 @@
+﻿using System;
+using System.Reflection;
+
+namespace RemoteTech.FlightComputer.Commands
+{
+    public class ExternalAPICommand : AbstractCommand
+    {
+
+        public ConfigNode externalData; //Config node passed to us be external group
+        public string description;
+        public string shortName;
+        public string reflectionGetType;
+        public string reflectionInvokeMember;
+        public string vslGUIDstr;
+        public Guid vslGUID;
+        public Vessel vsl;
+
+        public override string Description
+        {
+            get { return description; }
+        }
+        public override string ShortName { get { return shortName; } }
+
+        public override bool Pop(FlightComputer f)
+        {
+            Type calledType = Type.GetType(reflectionGetType); //
+            calledType.InvokeMember(reflectionInvokeMember, BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static, null, null, new System.Object[] { externalData });
+
+            return false;
+        }
+
+        
+    }
+}
+//public void AGXActivateGroup(ConfigNode externalData)
+//        {
+//            Type calledType = Type.GetType("ActionGroupsExtended.AGExtExternal, AGExt");
+//           calledType.InvokeMember("AGXReceiveData", BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static, null, null, new System.Object[] { externalData });
+//        }
+//}
+//}

--- a/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
@@ -7,13 +7,13 @@ namespace RemoteTech.FlightComputer.Commands
     {
 
         public ConfigNode externalData; //Config node passed to us be external group
-        public string description;
-        public string shortName;
-        public string reflectionGetType;
-        public string reflectionInvokeMember;
-        public string vslGUIDstr;
-        public Guid vslGUID;
-        public Vessel vsl;
+        public string description; //What displays on GUI
+        public string shortName; //no clue what this does
+        public string reflectionGetType; //needed for relfection method to pass data back
+        public string reflectionInvokeMember; //ditto
+        public string vslGUIDstr; //GUID of vessel, 99% of the time will be FlightGlobals.ActiveVessel
+        public Guid vslGUID; //GUID of vessel, as GUID
+        public Vessel vsl; 
 
         public override string Description
         {
@@ -23,15 +23,48 @@ namespace RemoteTech.FlightComputer.Commands
 
         public override bool Pop(FlightComputer f)
         {
-            Type calledType = Type.GetType(reflectionGetType); //
+            Type calledType = Type.GetType(reflectionGetType); //reflection methods
             calledType.InvokeMember(reflectionInvokeMember, BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static, null, null, new System.Object[] { externalData });
 
-            return false;
+            return false; //ActionGroupCommand returns false here, don't know why but do the same
         }
 
+        public override void Save(ConfigNode n, FlightComputer fc)
+        {
+            base.Save(n, fc); //run the remotetech save stuff
+            ConfigNode ExtAPI = n.GetNode("ExternalAPICommand"); //save passes a config node one level higher then the load method gets, compensate for that
+            ExtAPI.AddNode(externalData); //add our configNode of data
+            n.RemoveNode("ExternalAPICommand"); //ConfigNode.setNode does not work, use this instead
+            n.AddNode(ExtAPI);
+            
+        }
+        public override void Load(ConfigNode n, FlightComputer fc)
+        {
+            base.Load(n, fc); //load our basic remotetech stuff
+            externalData = n.nodes[0]; //load our data noe
+                description = externalData.GetValue("Description"); //string on GUI
+                shortName = externalData.GetValue("ShortName"); //???
+                reflectionGetType = externalData.GetValue("ReflectionGetType"); //required for reflection back
+                reflectionInvokeMember = externalData.GetValue("ReflectionInvokeMember"); //required 
+                vslGUIDstr = externalData.GetValue("GUIDString");
+
+                foreach (Vessel vsl2 in FlightGlobals.Vessels) //can not find a Guid.Parse method, so do it this way
+                {
+                    if (vsl2.id.ToString() == vslGUIDstr)
+                    {
+                        vslGUID = vsl2.id;
+                        vsl = vsl2;
+                    }
+                }
+            
+        }
+        
         
     }
 }
+
+//Example method from Action Groups Extended to pass configNode to Remotetech. Ref: https://github.com/SirDiazo/AGExt/blob/master/AGExt/Flight.cs#L1556
+//
 //public void AGXActivateGroup(ConfigNode externalData)
 //        {
 //            Type calledType = Type.GetType("ActionGroupsExtended.AGExtExternal, AGExt");
@@ -39,3 +72,29 @@ namespace RemoteTech.FlightComputer.Commands
 //        }
 //}
 //}
+
+//Example Method in AGX to receive data node back from Remtotech. Ref: https://github.com/SirDiazo/AGExt/blob/master/AGExt/External.cs#L584
+
+//public static void RTDataReceive(ConfigNode node) //receive data back from RT
+//        {
+//            Debug.Log("AGX Call: RemoteTechCallback");
+//            if (HighLogic.LoadedSceneIsFlight)
+//            {
+//                if (FlightGlobals.ActiveVessel.rootPart.flightID == Convert.ToUInt32(node.GetValue("FlightID")))
+//                {
+
+//                    AGXFlight.ActivateActionGroupActivation(Convert.ToInt32(node.GetValue("Group")), Convert.ToBoolean(node.GetValue("Force")), Convert.ToBoolean(node.GetValue("ForceDir")));
+                    
+//                }
+//                else
+//                {
+//                    AGXOtherVessel otherVsl = new AGXOtherVessel(Convert.ToUInt32(node.GetValue("FlightID")));
+//                    otherVsl.ActivateActionGroupActivation(Convert.ToInt32(node.GetValue("Group")), Convert.ToBoolean(node.GetValue("Force")), Convert.ToBoolean(node.GetValue("ForceDir")));
+//                }
+//            }
+//            else
+//            {
+//                ScreenMessages.PostScreenMessage("AGX Action Not Activated, Remotetech passed invalid vessel", 10F, ScreenMessageStyle.UPPER_CENTER);
+                
+//            }
+//        }

--- a/src/RemoteTech/RTCore.cs
+++ b/src/RemoteTech/RTCore.cs
@@ -101,7 +101,7 @@ namespace RemoteTech
 
         public void OnDestroy()
         {
-            if (FocusOverlay != null) FocusOverlay.Dispose();
+            if (FocusOverlay != null) FocusOverlay.Dispose(); 
             if (FilterOverlay != null) FilterOverlay.Dispose();
             if (FilterOverlay != null) FilterOverlay.Dispose();
             if (Renderer != null) Renderer.Detach();

--- a/src/RemoteTech/RemoteTech.csproj
+++ b/src/RemoteTech/RemoteTech.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\..\..\0.90 Dev\GameData\RemoteTech\Plugins\</OutputPath>
+    <OutputPath>..\..\GameData\RemoteTech\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -34,11 +34,8 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>..\..\..\..\0.90 Dev\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
+      <HintPath>Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
-    </Reference>
-    <Reference Include="Assembly-CSharp-firstpass">
-      <HintPath>..\..\..\..\0.90 Dev\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -47,7 +44,7 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>..\..\..\..\0.90 Dev\KSP_Data\Managed\UnityEngine.dll</HintPath>
+      <HintPath>UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>

--- a/src/RemoteTech/RemoteTech.csproj
+++ b/src/RemoteTech/RemoteTech.csproj
@@ -16,7 +16,7 @@
     <DebugSymbols>false</DebugSymbols>
     <DebugType>none</DebugType>
     <Optimize>false</Optimize>
-    <OutputPath>..\..\GameData\RemoteTech\Plugins\</OutputPath>
+    <OutputPath>..\..\..\..\0.90 Dev\GameData\RemoteTech\Plugins\</OutputPath>
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
@@ -34,8 +34,11 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="Assembly-CSharp">
-      <HintPath>Assembly-CSharp.dll</HintPath>
+      <HintPath>..\..\..\..\0.90 Dev\KSP_Data\Managed\Assembly-CSharp.dll</HintPath>
       <Private>False</Private>
+    </Reference>
+    <Reference Include="Assembly-CSharp-firstpass">
+      <HintPath>..\..\..\..\0.90 Dev\KSP_Data\Managed\Assembly-CSharp-firstpass.dll</HintPath>
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
@@ -44,13 +47,14 @@
     <Reference Include="System.Data" />
     <Reference Include="System.Xml" />
     <Reference Include="UnityEngine">
-      <HintPath>UnityEngine.dll</HintPath>
+      <HintPath>..\..\..\..\0.90 Dev\KSP_Data\Managed\UnityEngine.dll</HintPath>
       <Private>False</Private>
     </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="API\API.cs" />
     <Compile Include="FlightComputer\Commands\AbstractCommand.cs" />
+    <Compile Include="FlightComputer\Commands\ExternalAPICommand.cs" />
     <Compile Include="FlightComputer\Commands\ActionGroupCommand.cs" />
     <Compile Include="FlightComputer\Commands\AttitudeCommand.cs" />
     <Compile Include="FlightComputer\Commands\BurnCommand.cs" />


### PR DESCRIPTION
External Mod Code access.

A mod passes a config node to Remotech via code. After the signal delay has passed, Remotech then passes the same config node back to the external mod for the mod to activate. The code below assumes the mod will do all the processing, in this setup Remotetech is only serving as a signal delay on the command.

Using my AGX mod as a demo, here is the code in AGX to pass the configNode to Remotetech:
https://github.com/SirDiazo/AGExt/blob/master/AGExt/Flight.cs#L1571

In the ConfigNode passed, RemoteTech then pulls out the data it needs, Line 101 -105 in Remotetech.API, to make the ICommand to pass to the flight computer.

After the delay has passed, RemoteTech passes the ConfigNode back to the external mod under it's Pop method. Remotetech knows where to send the ConfigNode to by using the reflectionGetType and reflectionInvokeMember strings from the confignode when the mod originally passed it to remotetech.

In my test case, it targets this method in AGX.
https://github.com/SirDiazo/AGExt/blob/master/AGExt/External.cs#L584

Note the target name and method I passed to RemoteTech in the config node as the two reflection string values.

Note I have not extensively tested this, there seems to be something odd when trying to add extra time onto the signal delay via the number in the bottom of the flight computer window, but it throws no errors and the basic functionatiliy works.

Also note I have made no save/load provisions, this command is probably lost if you switch vessels or leave the flight scene at the moment. (I couldn't get my head around save/load in my time tonight, any suggestions?)

Does this code make sense, and does it work with your current code setup?

Also, currently the UI button is double height for some reason, what is going on here?
http://imgur.com/HjpJ0rj