### PR TITLE
Remove patch version from AssemblyVersion to prevent issues in dependent DLLs

### DIFF
--- a/src/RemoteTech/Properties/AssemblyInfo.cs
+++ b/src/RemoteTech/Properties/AssemblyInfo.cs
@@ -32,7 +32,11 @@ using System.Runtime.InteropServices;
 // You can specify all the values or you can default the Build and Revision Numbers 
 // by using the '*' as shown below:
 // [assembly: AssemblyVersion("1.0.*")]
-[assembly: AssemblyVersion("1.6.1")]
+
+// Don't include the patch revision in the AssemblyVersion - as this will break any dependent
+// DLLs any time it changes.  Breaking on a minor revision is probably acceptable - it's
+// unlikely that there wouldn't be other breaking changes on a minor version change.
+[assembly: AssemblyVersion("1.6")]
 [assembly: AssemblyFileVersion("1.6.1")]
 
 // Use KSPAssembly to allow other DLLs to make this DLL a dependency in a


### PR DESCRIPTION
I didn't really understand the distinction between AssemblyVersion, AssemblyFileVersion and AssemblyInformationalVersion until I read this aritcle:

http://www.danielfortunov.com/software/%24daniel_fortunovs_adventures_in_software_development/2009/03/03/assembly_versioning_in_net

In short - please don't update the the AssemblyVersion for major/minor releases, it'll make my life easier in Contract Configurator. :+1: 