### PR TITLE
255 inaccurate burns

### DIFF
--- a/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
@@ -12,14 +12,12 @@ namespace RemoteTech.FlightComputer.Commands
         public double RemainingTime;
         public double RemainingDelta;
         public ManeuverNode Node;
-        public bool EngineActivated { get; set; }
+        public bool EngineActivated { get; private set; }
         public override int Priority { get { return 0; } }
 
-        private double ticksRemaining = -1;
-        private float throttle = 1.0f;
-        private bool abortOnNextExecute = false;
-        private bool firstBurn = true;
+        private double throttle = 1.0f;
         private double lowestDeltaV = 0.0;
+        private bool abortOnNextExecute = false;
 
         public override string Description
         {
@@ -30,7 +28,7 @@ namespace RemoteTech.FlightComputer.Commands
                     string flightInfo = "Executing maneuver: " + RemainingDelta.ToString("F2") +
                                         "m/s" + Environment.NewLine + "Remaining duration: ";
 
-                    flightInfo += EngineActivated ? RTUtil.FormatDuration(RemainingTime) : "-:-";
+                    flightInfo += this.EngineActivated ? RTUtil.FormatDuration(RemainingTime) : "-:-";
 
                     return flightInfo + Environment.NewLine + base.Description;
                 }
@@ -48,12 +46,12 @@ namespace RemoteTech.FlightComputer.Commands
             }
 
             OriginalDelta = Node.DeltaV.magnitude;
-            RemainingDelta = Node.GetBurnVector(f.Vessel.orbit).magnitude;
-            EngineActivated = true;
+            RemainingDelta = this.getRemainingDeltaV(f);
+            this.EngineActivated = true;
 
             double thrustToMass = FlightCore.GetTotalThrust(f.Vessel) / f.Vessel.GetTotalMass();
             if (thrustToMass == 0.0) {
-                EngineActivated = false;
+                this.EngineActivated = false;
                 RTUtil.ScreenMessage("[Flight Computer]: No engine to carry out the maneuver.");
             } else {
                 RemainingTime = RemainingDelta / thrustToMass;
@@ -62,73 +60,93 @@ namespace RemoteTech.FlightComputer.Commands
             return true;
         }
 
-        public override bool Execute(FlightComputer f, FlightCtrlState fcs)
+        /// <summary>
+        /// Gets the current remaining delta velocity for this maneuver burn determined by the vessels burn vector of the passed FlightComputer instance.
+        /// </summary>
+        /// <param name="computer">FlightComputer instance to determine remaining delta velocity by.</param>
+        /// <returns>Remaining delta velocity in m/s^2</returns>
+        private double getRemainingDeltaV(FlightComputer computer)
         {
-            if (RemainingDelta > 0.01 && this.abortOnNextExecute == false)
+            return this.Node.GetBurnVector(computer.Vessel.orbit).magnitude;
+        }
+
+        /// <summary>
+        /// Executes the maneuver burn for the configured maneuver node.
+        /// </summary>
+        /// <param name="computer">FlightComputer instance of the computer of the vessel the ManeuverCommand is for.</param>
+        /// <param name="ctrlState">FlightCtrlState instance of the current state of the vessel.</param>
+        /// <returns>true if the command has finished its work, false otherwise.</returns>
+        public override bool Execute(FlightComputer computer, FlightCtrlState ctrlState)
+        {
+            // Halt the command if we reached our target or were command to abort by the previous tick
+            if (this.RemainingDelta <= 0.01 || this.abortOnNextExecute)
+            {    
+                computer.Enqueue(AttitudeCommand.KillRot(), true, true, true);
+                return true;
+            }
+
+            // Orientate vessel to maneuver prograde
+            var forward = Node.GetBurnVector(computer.Vessel.orbit).normalized;
+            var up = (computer.SignalProcessor.Body.position - computer.SignalProcessor.Position).normalized;
+            var orientation = Quaternion.LookRotation(forward, up);
+            FlightCore.HoldOrientation(ctrlState, computer, orientation);
+
+            // This represents the theoretical acceleration but is off by a few m/s^2, probably because some parts are partially physicsless
+            double thrustToMass = (FlightCore.GetTotalThrust(computer.Vessel) / computer.Vessel.GetTotalMass());
+            // We need to know if the engine was activated or not to show the proper info text in the command
+            if (thrustToMass == 0.0)
             {
-                var forward = Node.GetBurnVector(f.Vessel.orbit).normalized;
-                var up = (f.SignalProcessor.Body.position - f.SignalProcessor.Position).normalized;
-                var orientation = Quaternion.LookRotation(forward, up);
-                FlightCore.HoldOrientation(fcs, f, orientation);
+                this.EngineActivated = false;
+                return false;
+            }
+            this.EngineActivated = true;
 
-                double thrustToMass = (FlightCore.GetTotalThrust(f.Vessel) / f.Vessel.GetTotalMass());
-                if (thrustToMass == 0.0)
-                {
-                    EngineActivated = false;
-                    return false;
-                }
-      
-                EngineActivated = true;
+            // Before any throttling, those two values may differ from after the throttling took place
+            this.RemainingDelta = this.getRemainingDeltaV(computer);
+            this.RemainingTime = this.RemainingDelta / thrustToMass;
 
-                RemainingDelta = Node.GetBurnVector(f.Vessel.orbit).magnitude;
-                RemainingTime = RemainingDelta / thrustToMass;
-
-                // In case we would overpower with 100% thrust, calculate how much we actually need and set it.
-                if (f.Vessel.acceleration.magnitude > RemainingDelta)
-                {
-                    // Formula which leads to this: a = ( vE – vS ) / dT
-                    this.throttle = (float)RemainingDelta / (float)f.Vessel.acceleration.magnitude;
-                }
+            // In case we would overpower with 100% thrust, calculate how much we actually need and set it.
+            if (computer.Vessel.acceleration.magnitude > this.RemainingDelta)
+            {
+                // Formula which leads to this: a = ( vE – vS ) / dT
+                this.throttle = this.RemainingDelta / computer.Vessel.acceleration.magnitude;
+            }
                 
+            ctrlState.mainThrottle = (float)this.throttle;
 
-                ticksRemaining = RemainingTime / TimeWarp.deltaTime;
-       
+            // TODO: THIS CAN PROBABLY BE REMOVED? RemainingDelta = this.getRemainingDeltaV(computer);
 
-                fcs.mainThrottle = this.throttle;
+            // After throttling, the remaining time differs from beforehand (dividing delta by throttled thrustToMass)
+            this.RemainingTime = this.RemainingDelta / (ctrlState.mainThrottle * thrustToMass);
 
+            // We need to abort if the remaining delta was already low enough so it only takes exactly one more tick!
+            double ticksRemaining = this.RemainingTime / TimeWarp.deltaTime;
 
-                double throttledThrustToMass = fcs.mainThrottle * thrustToMass;
-
-                RemainingDelta = Node.GetBurnVector(f.Vessel.orbit).magnitude;
-                RemainingTime = RemainingDelta / throttledThrustToMass;
-
-                ticksRemaining = RemainingTime / TimeWarp.deltaTime;
-
-
-                // We need to abort if the remaining delta was already low enough so it only takes exactly one more tick!
-                if (ticksRemaining <= 1)
-                {
-                    fcs.mainThrottle = this.throttle * (float)ticksRemaining;
-                    this.abortOnNextExecute = true;
-                }
-
-                // we only compare up to the fiftieth part due to some inconsistency when just firing up the engines
-                if (this.lowestDeltaV > 0 && (RemainingDelta - 0.02) > this.lowestDeltaV)
-                {
-                    // Aborting because deltaV was rising again!
-                    f.Enqueue(AttitudeCommand.KillRot(), true, true, true);
-                    return true;
-                }
-                if (this.lowestDeltaV == 0 || RemainingDelta < this.lowestDeltaV)
-                {
-                    this.lowestDeltaV = RemainingDelta;
-                }
-
+            if (ticksRemaining <= 1)
+            {
+                this.throttle *= ticksRemaining;
+                ctrlState.mainThrottle = (float)this.throttle;
+                this.abortOnNextExecute = true;
                 return false;
             }
 
-            f.Enqueue(AttitudeCommand.KillRot(), true, true, true);
-            return true;
+            // we only compare up to the fiftieth part due to some burn-up delay when just firing up the engines
+            if (this.lowestDeltaV > 0 // Do ignore the first tick
+                && (this.RemainingDelta - 0.02) > this.lowestDeltaV)
+            {
+                // Aborting because deltaV was rising again!
+                computer.Enqueue(AttitudeCommand.KillRot(), true, true, true);
+                return true;
+            }
+
+            // Lowest delta always has to be stored to be able to compare it in the next tick
+            if (this.lowestDeltaV == 0 // Always do it on the first tick
+                || this.RemainingDelta < this.lowestDeltaV)
+            {
+                this.lowestDeltaV = this.RemainingDelta;
+            }
+
+            return false;
         }
 
         /// <summary>


### PR DESCRIPTION
This fixes #255.

The following tasks were accomplished:
- The remaining deltaV of the maneuver node is now correctly read from the API instead of calculated (the wrong way anyways)
- The current acceleration of the vessel now correctly read from the API instead of calculated (the wrong way anyways)
- I introduced a throttling mechanism at the end of the maneuver burn that aims to hit a target deltaV of 0.0m/s as close as possible. For this kind of new feature I would highly appreciate any comments and especially test results as I tried to cover all cases but one never knows.