### PR TITLE
Fixed KeyNotFoundException

### DIFF
--- a/src/RemoteTech/SatelliteManager.cs
+++ b/src/RemoteTech/SatelliteManager.cs
@@ -209,7 +209,7 @@ namespace RemoteTech
         public static ISignalProcessor GetSignalProcessor(this Vessel v)
         {
             RTLog.Notify("GetSignalProcessor({0}): Check", v.vesselName);
-            if (v.loaded)
+            if (v.loaded && v.parts.Count > 0)
             {
                 foreach (PartModule pm in v.Parts.SelectMany(p => p.Modules.Cast<PartModule>()).Where(pm => pm.IsSignalProcessor()))
                 {
@@ -242,7 +242,7 @@ namespace RemoteTech
         public static bool HasCommandStation(this Vessel v)
         {
             RTLog.Notify("HasCommandStation({0})", v.vesselName);
-            if (v.loaded)
+            if (v.loaded && v.parts.Count > 0)
             {
                 return v.Parts.SelectMany(p => p.Modules.Cast<PartModule>()).Any(pm => pm.IsCommandStation());
             }


### PR DESCRIPTION
The problem is that the `v.loaded` on the `GetSignalProcessor` method is still true after the vesselOnRails event. Thats why i also check the `part.count` like we do this on the `SatelliteManager.OnVesselOnRails` method, to search our values on the `ProtoPartModuleSnapshot`.

Fixes #92