### PR TITLE
Added a debug console for developing

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -13,7 +13,8 @@ namespace RemoteTech.API
             var satellite = RTCore.Instance.Satellites[id];
             if (satellite == null) return false;
             var hasFlightComputer = satellite.FlightComputer != null;
-            RTLog.Verbose("Flight: {0} HasFlightComputer: {1}", id, hasFlightComputer);
+            RTLog.Verbose("Flight: {0} HasFlightComputer: {1}", 6, id, hasFlightComputer);
+
             return hasFlightComputer;
         }
 
@@ -25,7 +26,7 @@ namespace RemoteTech.API
             {
                 if (spu.FlightComputer == null) continue;
                 if (spu.FlightComputer.SanctionedPilots.Contains(autopilot)) continue;
-                RTLog.Verbose("Flight: {0} Adding Sanctioned Pilot", id);
+                RTLog.Verbose("Flight: {0} Adding Sanctioned Pilot", 6, id);
                 spu.FlightComputer.SanctionedPilots.Add(autopilot);
             }
         }
@@ -37,7 +38,7 @@ namespace RemoteTech.API
             foreach (var spu in satellite.SignalProcessors)
             {
                 if (spu.FlightComputer == null) continue;
-                RTLog.Verbose("Flight: {0} Removing Sanctioned Pilot", id);
+                RTLog.Verbose("Flight: {0} Removing Sanctioned Pilot", 6, id);
                 spu.FlightComputer.SanctionedPilots.Remove(autopilot);
             }
         }
@@ -46,7 +47,7 @@ namespace RemoteTech.API
         {
             var satellite = RTCore.Instance.Satellites[id];
             var hasConnection = RTCore.Instance.Network[satellite].Any();
-            RTLog.Verbose("Flight: {0} Has Connection: {1}", id, hasConnection);
+            RTLog.Verbose("Flight: {0} Has Connection: {1}", 6, id, hasConnection);
             return hasConnection;
         }
 
@@ -54,7 +55,7 @@ namespace RemoteTech.API
         {
             var satellite = RTCore.Instance.Satellites[id];
             var connectedToKerbin = RTCore.Instance.Network[satellite].Any(r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Goal.Guid));
-            RTLog.Verbose("Flight: {0} Has Connection to Kerbin: {1}", id, connectedToKerbin);
+            RTLog.Verbose("Flight: {0} Has Connection to Kerbin: {1}", 6, id, connectedToKerbin);
             return connectedToKerbin;
         }
 
@@ -63,7 +64,7 @@ namespace RemoteTech.API
             var satellite = RTCore.Instance.Satellites[id];
             if (!RTCore.Instance.Network[satellite].Any()) return Double.PositiveInfinity;
             var shortestDelay = RTCore.Instance.Network[satellite].Min().Delay;
-            RTLog.Verbose("Flight: Shortest signal delay from {0} to {1}", id, shortestDelay);
+            RTLog.Verbose("Flight: Shortest signal delay from {0} to {1}", 6, id, shortestDelay);
             return shortestDelay;
         }
 
@@ -72,7 +73,7 @@ namespace RemoteTech.API
             var satellite = RTCore.Instance.Satellites[id];
             if (!RTCore.Instance.Network[satellite].Any(r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Goal.Guid))) return Double.PositiveInfinity;
             var signalDelaytoKerbin = RTCore.Instance.Network[satellite].Where(r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Goal.Guid)).Min().Delay;
-            RTLog.Verbose("Connection from {0} to Kerbin Delay: {1}", id, signalDelaytoKerbin);
+            RTLog.Verbose("Connection from {0} to Kerbin Delay: {1}", 6, id, signalDelaytoKerbin);
             return signalDelaytoKerbin;
         }
 
@@ -88,9 +89,10 @@ namespace RemoteTech.API
 
             var path = NetworkPathfinder.Solve(satelliteA, satelliteB, neighbors, cost, heuristic);
             var delayBetween = path.Delay;
-            RTLog.Verbose("Connection from {0} to {1} Delay: {2}", a, b, delayBetween);
+            RTLog.Verbose("Connection from {0} to {1} Delay: {2}", 6, a, b, delayBetween);
             return delayBetween;
         }
+
         public static void ReceiveData(ConfigNode ExternalData) //exposed method called by other mods, passing a ConfigNode to RemoteTech
         {
             if (ExternalData != null) //check we were actually passed a config node

--- a/src/RemoteTech/RTDebugUnit.cs
+++ b/src/RemoteTech/RTDebugUnit.cs
@@ -1,7 +1,5 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.Linq;
-using System.Text;
 using UnityEngine;
 
 namespace RemoteTech
@@ -9,12 +7,28 @@ namespace RemoteTech
     [KSPAddon(KSPAddon.Startup.EveryScene, false)]
     public class RTDebugUnit : MonoBehaviour
     {
+        private RemoteTech.UI.DebugWindow debugWindow = null;
+
+        public void Start()
+        {
+            #if DEBUG
+            this.debugWindow = new RemoteTech.UI.DebugWindow();
+            #endif
+        }
 
         public void Update()
         {
-            if (Input.GetKeyDown(KeyCode.F11) && HighLogic.LoadedSceneIsFlight)
+            if ((Input.GetKeyDown(KeyCode.F11) || Input.GetKeyDown(KeyCode.F12)) && (HighLogic.LoadedSceneIsFlight || HighLogic.LoadedSceneHasPlanetarium))
             {
-                Dump();
+                if (Input.GetKeyDown(KeyCode.F11)){
+                    Dump();
+                }
+                else {
+                    if (this.debugWindow != null)
+                    {
+                        this.debugWindow.toggleWindow();
+                    }
+                }
             }
         }
 

--- a/src/RemoteTech/RTLog.cs
+++ b/src/RemoteTech/RTLog.cs
@@ -5,46 +5,119 @@ namespace RemoteTech
 {
     public static class RTLog
     {
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value></value>
         private static readonly bool verboseLogging;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value></value>
+        public static int maxDebugLevels = 7;
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <value></value>
+        public static Dictionary<int, List<string>> RTLogList = new Dictionary<int, List<string>>();
 
+        /// <summary>
+        /// 
+        /// </summary>
         static RTLog()
         {
-            verboseLogging = GameSettings.VERBOSE_DEBUG_LOG;
+            RTLog.verboseLogging = GameSettings.VERBOSE_DEBUG_LOG;
+
+            #region ON-DEBUGMODE
+#if DEBUG
+            RTLog.verboseLogging = true;
+
+            for (int i = 0; i < RTLog.maxDebugLevels; i++)
+            {
+                RTLog.RTLogList.Add(i, new List<string>());
+            }
+#endif
+            #endregion
         }
 
-        public static void Notify(string message)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="param"></param>
+        /// <returns>formated string</returns>
+        public static string formatMessage(string message, params object[] param)
+        {
+            return string.Format(message, param);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        public static void Notify(string message, int debugLvl = 0)
         {
             UnityEngine.Debug.Log("RemoteTech: " + message);
+
+            #region ON-DEBUGMODE
+#if DEBUG
+            RTLog.NotifyToDebugLevel(message, debugLvl);
+#endif
+            #endregion
         }
 
-        public static void Notify(string message, params UnityEngine.Object[] param)
-        {
-            UnityEngine.Debug.Log(string.Format("RemoteTech: " + message, param));
-        }
-
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="param"></param>
         public static void Notify(string message, params object[] param)
         {
-            UnityEngine.Debug.Log(string.Format("RemoteTech: " + message, param));
+            RTLog.Notify(RTLog.formatMessage(message, param));
         }
 
-        public static void Verbose(string message, params object[] param)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        public static void Verbose(string message, int debugLvl = 0)
         {
             if (verboseLogging)
             {
-                Notify(message, param);
+                RTLog.Notify(message, debugLvl);
             }
         }
 
-        public static void Verbose(string message, params UnityEngine.Object[] param)
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="param"></param>
+        public static void Verbose(string message, int debugLvl, params object[] param)
         {
-            if (verboseLogging)
-            {
-                Notify(message, param);
-            }
+            RTLog.Verbose(RTLog.formatMessage(message, param), debugLvl);
+        }
+
+        /// <summary>
+        /// 
+        /// </summary>
+        /// <param name="message"></param>
+        /// <param name="Debuglevel"></param>
+        /// <param name="param"></param>
+        public static void NotifyToDebugLevel(string message, int Debuglevel, params object[] param)
+        {
+            #region ON-DEBUGMODE
+#if DEBUG
+            RTLog.RTLogList[Debuglevel].Add(message);
+#endif
+            #endregion
         }
     }
 
-    public static class LoggingExtenstions
+    /// <summary>
+    /// 
+    /// </summary>
+    public static class RTLogExtenstions
     {
         public static string ToDebugString<T>(this List<T> list)
         {

--- a/src/RemoteTech/RemoteTech.csproj
+++ b/src/RemoteTech/RemoteTech.csproj
@@ -108,6 +108,7 @@
     <Compile Include="UI\AntennaFragment.cs" />
     <Compile Include="UI\AntennaWindow.cs" />
     <Compile Include="UI\AttitudeFragment.cs" />
+    <Compile Include="UI\DebugWindow.cs" />
     <Compile Include="UI\FocusOverlay.cs" />
     <Compile Include="UI\FocusFragment.cs" />
     <Compile Include="UI\FlightComputerWindow.cs" />

--- a/src/RemoteTech/UI/AbstractWindow.cs
+++ b/src/RemoteTech/UI/AbstractWindow.cs
@@ -225,5 +225,17 @@ namespace RemoteTech.UI
         {
             InputLockManager.RemoveControlLock("RTLockControlForWindows");
         }
+
+        public void toggleWindow()
+        {
+            if (this.Enabled)
+            {
+                this.Hide();
+            }
+            else
+            {
+                this.Show();
+            }
+        }
     }
 }


### PR DESCRIPTION
I've added a Debug console for developing purposes only. You can open this window by pressing `F12` but only with a dll that you compiled in debug-mode. You can easily add a new section to this window but actually i've added four sections.

# RemoteTech Settings
Sometimes i want to do some flightcomputer tests with a high signal delay, or other things without restarting ksp for changing the RTSettings.
![rtsettings](https://cloud.githubusercontent.com/assets/7722222/6158838/d4d25774-b24e-11e4-9b58-3ad846dd03b4.png)

# Api-Tester
To Test and develop new API methods.
![api-tester](https://cloud.githubusercontent.com/assets/7722222/6158852/f1b01dd6-b24e-11e4-994b-199290005729.png)

# Guid-Reader
You can see the current guid's for each vessel and ground stations. Just copy the guid and use it for the api tester.
![guidreader](https://cloud.githubusercontent.com/assets/7722222/6158933/da7b68ea-b24f-11e4-9ea5-bf78ca630846.png)

# Debuglogs ( you will only see RemoteTech logs)
On the bottom of this window is a small debug log where you can find only the remotetech notifys oder verbose logs. I also changed the notify methods to give them an `debugLvl: int` to filter your current logs on a new log-window. Current APi-Calls will be logged into Lvl6
![logger](https://cloud.githubusercontent.com/assets/7722222/6158964/396ccf06-b250-11e4-87ba-c125a8feab90.png)
