### PR TITLE
Local control API call

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -8,6 +8,15 @@ namespace RemoteTech.API
 {
     public static class API
     {
+        public static bool HasLocalControl(Guid id)
+        {
+            var satellite = RTCore.Instance.Satellites[id];
+            if (satellite == null) return false;
+            RTLog.Verbose("Flight: {0} HasLocalControl: {1}", RTLogLevel.API, id, satellite.HasLocalControl);
+
+            return satellite.HasLocalControl;
+        }
+
         public static bool HasFlightComputer(Guid id)
         {
             var satellite = RTCore.Instance.Satellites[id];
@@ -93,37 +102,33 @@ namespace RemoteTech.API
             return delayBetween;
         }
 
-        public static void ReceiveData(ConfigNode ExternalData) //exposed method called by other mods, passing a ConfigNode to RemoteTech
+        public static void ReceiveData(ConfigNode externalData) //exposed method called by other mods, passing a ConfigNode to RemoteTech
         {
-            if (ExternalData != null) //check we were actually passed a config node
+            if (externalData == null) return; //check we were actually passed a config node
+
+            try
             {
-                try
+                var extCmd = new FlightComputer.Commands.ExternalAPICommand //make our command
                 {
-                    RemoteTech.FlightComputer.Commands.ExternalAPICommand extCmd = new RemoteTech.FlightComputer.Commands.ExternalAPICommand() //make our command
-                    {
-                        externalData = ExternalData,
-                        TimeStamp = RTUtil.GameTime,
-                        description = ExternalData.GetValue("Description"), //string on GUI
-                        shortName = ExternalData.GetValue("ShortName"), //???
-                        reflectionGetType = ExternalData.GetValue("ReflectionGetType"), //required for reflection back
-                        reflectionInvokeMember = ExternalData.GetValue("ReflectionInvokeMember"), //required 
-                        vslGUIDstr = ExternalData.GetValue("GUIDString"),
-                    };
-                    foreach (Vessel vsl2 in FlightGlobals.Vessels) //can not find a Guid.Parse method, so do it this way
-                    {
-                        if (vsl2.id.ToString() == extCmd.vslGUIDstr)
-                        {
-                            extCmd.vslGUID = vsl2.id;
-                            extCmd.vsl = vsl2;
-                        }
-                    }
-                    RemoteTech.FlightComputer.FlightComputer fltComp = RTCore.Instance.Satellites[extCmd.vslGUID].FlightComputer;
-                    fltComp.Enqueue(extCmd);
-                }
-                catch
+                    externalData = externalData,
+                    TimeStamp = RTUtil.GameTime,
+                    description = externalData.GetValue("Description"), //string on GUI
+                    shortName = externalData.GetValue("ShortName"), //???
+                    reflectionGetType = externalData.GetValue("ReflectionGetType"), //required for reflection back
+                    reflectionInvokeMember = externalData.GetValue("ReflectionInvokeMember"), //required 
+                    vslGUIDstr = externalData.GetValue("GUIDString"),
+                };
+                foreach (Vessel vsl2 in FlightGlobals.Vessels.Where(vsl2 => vsl2.id.ToString() == extCmd.vslGUIDstr))
                 {
-                    RTDebugUnit.print("RT Error: Invalid ConfigNode passed by other mod");
+                    extCmd.vslGUID = vsl2.id;
+                    extCmd.vsl = vsl2;
                 }
+                FlightComputer.FlightComputer fltComp = RTCore.Instance.Satellites[extCmd.vslGUID].FlightComputer;
+                fltComp.Enqueue(extCmd);
+            }
+            catch
+            {
+                RTLog.Notify("Invalid ConfigNode passed by other mod");
             }
         }
     }

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -128,7 +128,7 @@ namespace RemoteTech.API
             }
             catch
             {
-                RTLog.Notify("Invalid ConfigNode passed by other mod");
+                RTLog.Notify("Invalid ConfigNode passed by other mod", RTLogLevel.API);
             }
         }
     }

--- a/src/RemoteTech/RTLog.cs
+++ b/src/RemoteTech/RTLog.cs
@@ -26,17 +26,17 @@ namespace RemoteTech
 
         static RTLog()
         {
-            RTLog.verboseLogging = GameSettings.VERBOSE_DEBUG_LOG;
+            verboseLogging = GameSettings.VERBOSE_DEBUG_LOG;
 
             #region ON-DEBUGMODE
 #if DEBUG
             // always set the verboseLogging to true on debug mode
-            RTLog.verboseLogging = true;
+            verboseLogging = true;
 
             // initialize debug list
             foreach (RTLogLevel lvl in Enum.GetValues(typeof(RTLogLevel)))
             {
-                RTLog.RTLogList.Add(lvl, new List<string>());
+                RTLogList.Add(lvl, new List<string>());
             }
 #endif
             #endregion
@@ -44,17 +44,17 @@ namespace RemoteTech
         
         /// <summary>
         /// Notify a message to the log. In debug mode the message will also be logged 
-        /// to the <paramref name="LogLevel"/> list.
+        /// to the <paramref name="logLevel"/> list.
         /// </summary>
         /// <param name="message">Message to log</param>
-        /// <param name="LogLevel">Loglevel for debugging</param>
-        public static void Notify(string message, RTLogLevel LogLevel = RTLogLevel.LVL1)
+        /// <param name="logLevel">Loglevel for debugging</param>
+        public static void Notify(string message, RTLogLevel logLevel = RTLogLevel.LVL1)
         {
             UnityEngine.Debug.Log("RemoteTech: " + message);
 
             #region ON-DEBUGMODE
 #if DEBUG
-            RTLog.NotifyToLogLevel(message, LogLevel);
+            NotifyToLogLevel(message, logLevel);
 #endif
             #endregion
         }
@@ -67,34 +67,34 @@ namespace RemoteTech
         /// <param name="param">objects to format</param>
         public static void Notify(string message, params object[] param)
         {
-            RTLog.Notify(string.Format(message, param));
+            Notify(string.Format(message, param));
         }
 
         /// <summary>
         /// Notify a message to the log. Replaces each format item on the <paramref name="message"/>
         /// with the text equivalent of a corresponding objects value from <paramref name="param"/>.
-        /// In debug mode the message will also be logged to the <paramref name="LogLevel"/> list.
+        /// In debug mode the message will also be logged to the <paramref name="logLevel"/> list.
         /// </summary>
         /// <param name="message">Message to log with format items</param>
-        /// <param name="LogLevel">Loglevel for debugging</param>
+        /// <param name="logLevel">Loglevel for debugging</param>
         /// <param name="param">objects to format</param>
-        public static void Notify(string message, RTLogLevel LogLevel = RTLogLevel.LVL1, params object[] param)
+        public static void Notify(string message, RTLogLevel logLevel = RTLogLevel.LVL1, params object[] param)
         {
-            RTLog.Notify(string.Format(message, param), LogLevel);
+            Notify(string.Format(message, param), logLevel);
         }
 
         /// <summary>
         /// Notify a message to the log only if the VERBOSE_DEBUG_LOG from the ksp settings.cfg
         /// is set to true. In debug mode the message will also be logged to the
-        /// <paramref name="LogLevel"/> list.
+        /// <paramref name="logLevel"/> list.
         /// </summary>
         /// <param name="message">Message to log</param>
-        /// <param name="LogLevel">Loglevel for debugging</param>
-        public static void Verbose(string message, RTLogLevel LogLevel = RTLogLevel.LVL1)
+        /// <param name="logLevel">Loglevel for debugging</param>
+        public static void Verbose(string message, RTLogLevel logLevel = RTLogLevel.LVL1)
         {
-            if (RTLog.verboseLogging)
+            if (verboseLogging)
             {
-                RTLog.Notify(message, LogLevel);
+                Notify(message, logLevel);
             }
         }
 
@@ -102,24 +102,24 @@ namespace RemoteTech
         /// Notify a message to the log only if the VERBOSE_DEBUG_LOG from the ksp settings.cfg
         /// is set to true. Replaces each format item on the <paramref name="message"/>
         /// with the text equivalent of a corresponding objects value from <paramref name="param"/>.
-        /// In debug mode the message will also be logged to the <paramref name="LogLevel"/> list.
+        /// In debug mode the message will also be logged to the <paramref name="logLevel"/> list.
         /// </summary>
         /// <param name="message">Message to log</param>
-        /// <param name="LogLevel">Loglevel for debugging</param>
+        /// <param name="logLevel">Loglevel for debugging</param>
         /// <param name="param">objects to format</param>
-        public static void Verbose(string message, RTLogLevel LogLevel = RTLogLevel.LVL1, params object[] param)
+        public static void Verbose(string message, RTLogLevel logLevel = RTLogLevel.LVL1, params object[] param)
         {
-            RTLog.Verbose(string.Format(message, param), LogLevel);
+            Verbose(string.Format(message, param), logLevel);
         }
 
         /// <summary>
-        /// Logs the <paramref name="message"/> to the <paramref name="LogLevel"/>
+        /// Logs the <paramref name="message"/> to the <paramref name="logLevel"/>
         /// </summary>
         /// <param name="message">Message to log</param>
-        /// <param name="LogLevel">Loglevel for debugging</param>
-        private static void NotifyToLogLevel(string message, RTLogLevel LogLevel)
+        /// <param name="logLevel">Loglevel for debugging</param>
+        private static void NotifyToLogLevel(string message, RTLogLevel logLevel)
         {
-            RTLog.RTLogList[LogLevel].Add(message);
+            RTLogList[logLevel].Add(message);
         }
     }
 


### PR DESCRIPTION
This adds HasLocalControl to the API, i was building an interface for users in kOS to query stuff about remotetech and i realized i had a few places were we were doing the same calculation that RT is for determining local control. 

If RTs definition for that ever changes, kOS would be out of sync so this new endpoint made sense.