### PR TITLE
Added "Addon"-loader

### DIFF
--- a/src/RemoteTech/AddOns/ControlLockAPI.cs
+++ b/src/RemoteTech/AddOns/ControlLockAPI.cs
@@ -1,0 +1,71 @@
+﻿using RemoteTech.SimpleTypes;
+
+namespace RemoteTech.AddOns
+{
+    /// <summary>
+    /// This class connects to the KSP-Addon ControlLock, created by Diazo
+    /// to keep the inputs of Linux users to the focused input fields.
+    /// Topic: http://forum.kerbalspaceprogram.com/threads/108561
+    /// </summary>
+    public class ControlLockAddon : AddOn
+    {
+        public ControlLockAddon()
+            : base("ControlLock", "ControlLock.ControlLock")
+        {
+        }
+
+        /// <summary>
+        /// Is the control lock set by a specific <paramref name="modname"/>?
+        /// The string is the same string as passed to SetFullLock. Note
+        /// that this method can return false that it is not locked by
+        /// a mod, but another mod is enforcing the control lock.
+        /// </summary>
+        /// <param name="modName">Name of the mod who set the lock</param>
+        /// <returns>true if lock is the for the mod</returns>
+        public bool IsLockSet(string modName)
+        {
+            var result = this.invoke(new System.Object[] { modName });
+
+            if (result != null) return (bool)result;
+            return false;
+        }
+
+        /// <summary>
+        /// Check if the control lock is set, yes or no.
+        /// </summary>
+        /// <returns>true for lock is set, otherwise false</returns>
+        public bool IsLockSet()
+        {
+            var result = this.invoke(null);
+
+            if (result!=null) return (bool)result;
+            return false;
+        }
+
+        /// <summary>
+        /// Pass this method a string, I recommend the name of your
+        /// <paramref name="modname"/>, to engage the lock. Note you
+        /// can pass the same lock multiple times, this mod will
+        /// detect that and only lock controls the first time the
+        /// mod is locked after being unlocked.
+        /// </summary>
+        /// <param name="modName">Name of the mod to set the lock</param>
+        public void SetFullLock(string modName)
+        {
+            this.invoke(new System.Object[] { modName });
+        }
+
+        /// <summary>
+        /// Pass the <paramref name="modname"/> of your control lock
+        /// to unset the lock. This is the same string (capitilization
+        /// matters) that you passed in the SetFullLock command.
+        /// It is safe to pass this with an invalid string,
+        /// nothing will happen.
+        /// </summary>
+        /// <param name="modName">Name of the mod to unlock</param>
+        public void UnsetFullLock(string modName)
+        {
+            this.invoke(new System.Object[] { modName });
+        }
+    }
+}

--- a/src/RemoteTech/RTCore.cs
+++ b/src/RemoteTech/RTCore.cs
@@ -16,6 +16,9 @@ namespace RemoteTech
         public NetworkManager Network { get; protected set; }
         public NetworkRenderer Renderer { get; protected set; }
 
+        /// Addons
+        public AddOns.ControlLockAddon ctrlLockAddon { get; protected set; }
+
         public event Action OnFrameUpdate = delegate { };
         public event Action OnPhysicsUpdate = delegate { };
         public event Action OnGuiUpdate = delegate { };
@@ -33,6 +36,8 @@ namespace RemoteTech
             }
 
             Instance = this;
+
+            ctrlLockAddon = new AddOns.ControlLockAddon();
 
             Satellites = new SatelliteManager();
             Antennas = new AntennaManager();

--- a/src/RemoteTech/RTLog.cs
+++ b/src/RemoteTech/RTLog.cs
@@ -13,7 +13,8 @@ namespace RemoteTech
         LVL2,
         LVL3,
         LVL4,
-        API
+        API,
+        Assembly
     };
 
     public static class RTLog

--- a/src/RemoteTech/RemoteTech.csproj
+++ b/src/RemoteTech/RemoteTech.csproj
@@ -49,6 +49,7 @@
     </Reference>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AddOns\ControlLockAPI.cs" />
     <Compile Include="API\API.cs" />
     <Compile Include="FlightComputer\Commands\AbstractCommand.cs" />
     <Compile Include="FlightComputer\Commands\ExternalAPICommand.cs" />
@@ -94,6 +95,7 @@
     <Compile Include="RTUtil.cs" />
     <Compile Include="SatelliteManager.cs" />
     <Compile Include="AntennaManager.cs" />
+    <Compile Include="SimpleTypes\AddOn.cs" />
     <Compile Include="SimpleTypes\BidirectionalEdge.cs" />
     <Compile Include="SimpleTypes\BinaryHeap.cs" />
     <Compile Include="SimpleTypes\CachedField.cs" />

--- a/src/RemoteTech/RemoteTech.csproj
+++ b/src/RemoteTech/RemoteTech.csproj
@@ -126,6 +126,7 @@
     <Compile Include="UI\TargetInfoFragment.cs" />
     <Compile Include="UI\TargetInfoWindow.cs" />
     <Compile Include="UI\TimeWarpDecorator.cs" />
+    <Compile Include="VesselExtension.cs" />
     <Compile Include="VesselSatellite.cs" />
     <Compile Include="RangeModel\AbstractRangeModel.cs" />
     <Compile Include="NetworkFeedback.cs" />

--- a/src/RemoteTech/SimpleTypes/AddOn.cs
+++ b/src/RemoteTech/SimpleTypes/AddOn.cs
@@ -1,0 +1,67 @@
+﻿using System;
+using System.Diagnostics;
+using System.Linq;
+using System.Reflection;
+
+namespace RemoteTech.SimpleTypes
+{
+    public abstract class AddOn
+    {
+        private bool loaded = false;
+        /// <summary>Holds the current assembly type</summary>
+        private Type assemblyType;
+        /// <summary>Binding flags for invoking the methods</summary>
+        private BindingFlags bFlags = BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static;
+
+        /// <summary>Assemlby loaded?</summary>
+        public bool assemblyLoaded { get { return this.loaded; } }
+
+
+        protected AddOn(string assemblyName, string assemblyType)
+        {
+            RTLog.Notify("Connecting with {0} ...", RTLogLevel.Assembly, assemblyName);
+
+            var loadedAssembly = AssemblyLoader.loadedAssemblies.FirstOrDefault(a => a.assembly.GetName().Name.Equals(assemblyName));
+            if (loadedAssembly != null)
+            {
+                RTLog.Notify("Successfull connected to Assembly {0}", RTLogLevel.Assembly, assemblyName);
+                this.assemblyType = loadedAssembly.assembly.GetTypes().FirstOrDefault(t => t.FullName.Equals(assemblyType));
+
+                this.loaded = true;
+            }
+        }
+
+        /// <summary>
+        /// Reads the current called method name and takes this method
+        /// over to the assembly. The return value on a not successfull
+        /// call is null.
+        /// </summary>
+        /// <param name="parameters">Object parameter list, given to the assembly method</param>
+        /// <returns>Null on a non successfull call</returns>
+        protected object invoke(object[] parameters)
+        {
+            if(this.assemblyLoaded)
+            {
+                try
+                {
+                    // look 1 call behind to get the name of the method who is called
+                    StackTrace st = new StackTrace();
+                    StackFrame sf = st.GetFrame(1);
+
+                    // invoke the method
+                    var result = assemblyType.InvokeMember(sf.GetMethod().Name, bFlags, null, null, parameters);
+                    RTLog.Verbose("AddOn.InvokeResult for {0} is '{1}'", RTLogLevel.Assembly, sf.GetMethod().Name, result);
+
+                    return result;
+                }
+                catch (Exception ex)
+                {
+                    RTLog.Verbose("Exception from {0}", RTLogLevel.Assembly, ex);
+                }
+            }
+
+            // default value is null
+            return null;
+        }
+    }
+}

--- a/src/RemoteTech/UI/AbstractWindow.cs
+++ b/src/RemoteTech/UI/AbstractWindow.cs
@@ -210,10 +210,13 @@ namespace RemoteTech.UI
         /// </summary>
         public void setWindowCtrlLock()
         {
-            // only if we are enabled
-            if (Enabled)
+            // only if we are enabled and the controllock is not set
+            if (Enabled && InputLockManager.GetControlLock("RTLockControlForWindows") == ControlTypes.None)
             {
                 InputLockManager.SetControlLock(ControlTypes.ALL_SHIP_CONTROLS, "RTLockControlForWindows");
+
+                if (!RTCore.Instance.ctrlLockAddon.IsLockSet())
+                    RTCore.Instance.ctrlLockAddon.SetFullLock("RemoteTech");
             }
         }
 
@@ -223,7 +226,14 @@ namespace RemoteTech.UI
         /// </summary>
         public void removeWindowCtrlLock()
         {
-            InputLockManager.RemoveControlLock("RTLockControlForWindows");
+            // only if the controllock is set
+            if (InputLockManager.GetControlLock("RTLockControlForWindows") != ControlTypes.None)
+            {
+                InputLockManager.RemoveControlLock("RTLockControlForWindows");
+
+                if (RTCore.Instance.ctrlLockAddon.IsLockSet("RemoteTech"))
+                    RTCore.Instance.ctrlLockAddon.UnsetFullLock("RemoteTech");
+            }
         }
 
         public void toggleWindow()


### PR DESCRIPTION
I've created a new class called `ControlLockAddon` to soft-bind RemoteTech with the new Addon ControlLock created by Diazo. I also created a second class who controls the invokes to the connected
assembly, called `AddOn`.

Also changed:
- a new RTLogLevel = Assembly
- our CtrLock method from `AbstractWindow.setWindowCtrlLock` checks now
if our controlLock is set before setting a new or evene remove

Fixes #197