### PR TITLE
LLL config correction

### DIFF
--- a/GameData/RemoteTech/RemoteTech_LLL_Antennas.cfg
+++ b/GameData/RemoteTech/RemoteTech_LLL_Antennas.cfg
@@ -28,7 +28,7 @@
 
 // Communotron 64
 // Same mass as LLL's Communotron 32
-@PART[LLLCommPole2]:AFTER[LLL]:NEEDS[RemoteTech]
+@PART[LLLCommPole]:AFTER[LLL]:NEEDS[RemoteTech]
 {
 	!MODULE[ModuleDataTransmitter] {}
 	

--- a/GameData/RemoteTech/RemoteTech_LLL_Probes.cfg
+++ b/GameData/RemoteTech/RemoteTech_LLL_Probes.cfg
@@ -70,3 +70,19 @@
 		}
 	}
 }
+
+@PART[LLLMicrochip]
+{
+	MODULE
+	{
+		name = ModuleSPU
+		IsRTCommandStation = true
+	}
+	
+	MODULE
+	{
+		name = ModuleRTAntennaPassive
+		TechRequired = unmannedTech
+		OmniRange = 2
+	}
+}


### PR DESCRIPTION
- changed the double definition of the `LLLCommPole2` to `LLLCommPole`
- added LLLMicrochip (hint of Random Tank from the forum) the definition i use is from the LLL RT.cfg

fixes #339