### PR TITLE
ExternalApiCommand refactoring

### DIFF
--- a/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
@@ -68,7 +68,8 @@ namespace RemoteTech.FlightComputer.Commands
         /// </summary>
         /// <param name="n">Node with the command infos</param>
         /// <param name="fc">Current flightcomputer</param>
-        public virtual void Load(ConfigNode n, FlightComputer fc)
+        /// <returns>true - loaded successfull</returns>
+        public virtual bool Load(ConfigNode n, FlightComputer fc)
         {
             // nothing
             if (n.HasValue("TimeStamp"))
@@ -79,6 +80,8 @@ namespace RemoteTech.FlightComputer.Commands
             {
                 ExtraDelay = double.Parse(n.GetValue("ExtraDelay"));
             }
+
+            return true;
         }
         
         /// <summary>
@@ -109,7 +112,11 @@ namespace RemoteTech.FlightComputer.Commands
             {
                 ConfigNode.LoadObjectFromConfig(command, n);
                 // additional loadings
-                command.Load(n, fc);
+                var result = command.Load(n, fc);
+                RTLog.Verbose("Loading command {0}={1}", RTLogLevel.LVL1, n.name, result);
+                // delete command if we can't load the command correctlys
+                if (result == false)
+                    command = null;
             }
 
             return command;

--- a/src/RemoteTech/FlightComputer/Commands/CancelCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/CancelCommand.cs
@@ -47,10 +47,15 @@ namespace RemoteTech.FlightComputer.Commands
         /// <summary>
         /// Load the saved CancelCommand and find the element to cancel, based on the saved queue position
         /// </summary>
-        public override void Load(ConfigNode n, FlightComputer fc)
+        /// <returns>true - loaded successfull</returns>
+        public override bool Load(ConfigNode n, FlightComputer fc)
         {
-            base.Load(n, fc);
-            Command = fc.QueuedCommands.ElementAt(queueIndex);
+            if(base.Load(n, fc))
+            {
+                Command = fc.QueuedCommands.ElementAt(queueIndex);
+                return true;
+            }
+            return false;
         }
 
         /// <summary>

--- a/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
@@ -5,96 +5,213 @@ namespace RemoteTech.FlightComputer.Commands
 {
     public class ExternalAPICommand : AbstractCommand
     {
+        /// <summary>Name of the mod who passed this command</summary>
+        [Persistent] private string Executor;
+        /// <summary>Label for this command on the queue</summary>
+        [Persistent] private string QueueLabel;
+        /// <summary>Label for this command if its active</summary>
+        [Persistent] private string ActiveLabel;
+        /// <summary>Label for alert on no power</summary>
+        [Persistent] private string ShortLabel;
+        /// <summary>The ReflectionType for the methods to invoke</summary>
+        [Persistent] private string ReflectionType;
+        /// <summary>Name of the Pop-method on the ReflectionType</summary>
+        [Persistent] private string ReflectionPopMethod = "";
+        /// <summary>Name of the Execution-method on the ReflectionType</summary>
+        [Persistent] private string ReflectionExecuteMethod = "";
+        /// <summary>Name of the Abort-method on the ReflectionType</summary>
+        [Persistent] private string ReflectionAbortMethod = "";
+        /// <summary>GUID of the vessel</summary>
+        [Persistent] private string GUIDString;
+        /// <summary>true - when this command will be aborted</summary>
+        private bool AbortCommand = false;
 
-        public ConfigNode externalData; //Config node passed to us be external group
-        public string description; //What displays on GUI
-        public string shortName; //no clue what this does
-        public string reflectionGetType; //needed for relfection method to pass data back
-        public string reflectionInvokeMember; //ditto
-        public string vslGUIDstr; //GUID of vessel, 99% of the time will be FlightGlobals.ActiveVessel
-        public Guid vslGUID; //GUID of vessel, as GUID
-        public Vessel vsl; 
+        public override int Priority { get { return 0; } }
 
+        /// <summary>
+        /// Returns the <see cref="QueueLabel"/> of this command on the queue and the
+        /// <see cref="ActiveLabel"/> if this command is active. If no one is defined
+        /// the <see cref="Executor"/> will be returned.
+        /// </summary>
         public override string Description
         {
-            get { return description + Environment.NewLine + base.Description; }
+            get
+            {
+                var desc = (this.QueueLabel == "") ? this.Executor : this.QueueLabel;
+
+                if(this.Delay <= 0 && this.ExtraDelay <= 0)
+                    desc = (this.ActiveLabel == "") ? this.Executor : this.ActiveLabel;
+
+                return desc + Environment.NewLine + base.Description;
+            }
         }
-        public override string ShortName { get { return shortName; } }
 
-        public override bool Pop(FlightComputer f)
+        /// <summary>
+        /// Returns the <see cref="ShortLabel"/> of this command. If no <see cref="ShortLabel"/>
+        /// is defined the name of the <see cref="Executor"/> will be returned.
+        /// </summary>
+        public override string ShortName
         {
-            Type calledType = Type.GetType(reflectionGetType); //reflection methods
-            calledType.InvokeMember(reflectionInvokeMember, BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static, null, null, new System.Object[] { externalData });
-
-            return false; //ActionGroupCommand returns false here, don't know why but do the same
+            get { return (this.ShortLabel == "") ? this.Executor : this.ShortLabel; }
         }
 
-        public override void Save(ConfigNode n, FlightComputer fc)
+        /// <summary>
+        /// Pops the command and invokes the <see cref="ReflectionPopMethod"/> on the
+        /// <see cref="ReflectionType"/>.
+        /// </summary>
+        /// <param name="computer">Current flightcomputer</param>
+        /// <returns>true: move to active.</returns>
+        public override bool Pop(FlightComputer computer)
         {
-            base.Save(n, fc); //run the remotetech save stuff
-            ConfigNode ExtAPI = n.GetNode("ExternalAPICommand"); //save passes a config node one level higher then the load method gets, compensate for that
-            ExtAPI.AddNode(externalData); //add our configNode of data
-            n.RemoveNode("ExternalAPICommand"); //ConfigNode.setNode does not work, use this instead
-            n.AddNode(ExtAPI);
-            
-        }
-        public override void Load(ConfigNode n, FlightComputer fc)
-        {
-            base.Load(n, fc); //load our basic remotetech stuff
-            externalData = n.nodes[0]; //load our data noe
-                description = externalData.GetValue("Description"); //string on GUI
-                shortName = externalData.GetValue("ShortName"); //???
-                reflectionGetType = externalData.GetValue("ReflectionGetType"); //required for reflection back
-                reflectionInvokeMember = externalData.GetValue("ReflectionInvokeMember"); //required 
-                vslGUIDstr = externalData.GetValue("GUIDString");
+            bool moveToActive = false;
 
-                foreach (Vessel vsl2 in FlightGlobals.Vessels) //can not find a Guid.Parse method, so do it this way
+            if (this.ReflectionPopMethod != "")
+            {
+                // invoke the Pop-method
+                moveToActive = (bool)this.callReflectionMember(this.ReflectionPopMethod);
+
+                // set moveToActive to false if we've no Execute-method.
+                if (this.ReflectionExecuteMethod == "") moveToActive = false;
+            }
+
+            return moveToActive;
+        }
+
+        /// <summary>
+        /// Executes this command and invokes the <see cref="ReflectionExecuteMethod"/>
+        /// on the <see cref="ReflectionType"/>. When this command is aborted the
+        /// fallback commnd is "KillRot".
+        /// </summary>
+        /// <param name="computer">Current flightcomputer</param>
+        /// <param name="ctrlState">Current FlightCtrlState</param>
+        /// <returns>true: delete afterwards.</returns>
+        public override bool Execute(FlightComputer computer, FlightCtrlState ctrlState)
+        {
+            bool finished = true;
+
+            if (this.ReflectionExecuteMethod != "")
+            {
+                // invoke the Execution-method
+                finished = (bool)this.callReflectionMember(this.ReflectionExecuteMethod);
+                if (this.AbortCommand)
                 {
-                    if (vsl2.id.ToString() == vslGUIDstr)
-                    {
-                        vslGUID = vsl2.id;
-                        vsl = vsl2;
-                    }
+                    // enqueue killRot after aborting this command
+                    computer.Enqueue(AttitudeCommand.KillRot(), true, true, true);
+                    finished = true;
                 }
-            
+            }
+
+            return finished;
         }
-        
+
+        /// <summary>
+        /// Aborts the active external command and invokes the
+        /// <see cref="ReflectionAbortMethod"/> on the <see cref="ReflectionType"/>. 
+        /// </summary>
+        public override void Abort()
+        {
+            this.AbortCommand = true;
+
+            if (this.ReflectionAbortMethod != "")
+            {
+                this.callReflectionMember(this.ReflectionAbortMethod);
+            }
+        }
+
+        /// <summary>
+        /// Configures an ExternalAPICommand.
+        /// </summary>
+        /// <param name="externalData">Data passed by the Api.QueueCommandToFlightComputer</param>
+        /// <returns>Configured ExternalAPICommand</returns>
+        public static ExternalAPICommand FromExternal(ConfigNode externalData)
+        {
+            ExternalAPICommand command =  new ExternalAPICommand();
+            command.TimeStamp = RTUtil.GameTime;
+            command.Executor = externalData.GetValue("Executor");
+            command.ReflectionType = externalData.GetValue("ReflectionType");
+            command.GUIDString = externalData.GetValue("GUIDString");
+
+            if (externalData.HasValue("QueueLabel"))
+                command.QueueLabel = externalData.GetValue("QueueLabel");
+            if (externalData.HasValue("ActiveLabel"))
+                command.ActiveLabel = externalData.GetValue("ActiveLabel");
+            if (externalData.HasValue("ShortLabel"))
+                command.ShortLabel = externalData.GetValue("ShortLabel");
+
+
+            if (externalData.HasValue("ReflectionPopMethod"))
+                command.ReflectionPopMethod = externalData.GetValue("ReflectionPopMethod");
+            if (externalData.HasValue("ReflectionExecuteMethod"))
+                command.ReflectionExecuteMethod = externalData.GetValue("ReflectionExecuteMethod");
+            if (externalData.HasValue("ReflectionAbortMethod"))
+                command.ReflectionAbortMethod = externalData.GetValue("ReflectionAbortMethod");
+
+            return command;
+        }
+
+        /// <summary>
+        /// Loads the ExternalAPICommand from the persistent file. If the loading
+        /// can't find the <see cref="ReflectionType"/> we'll notify a ScreenMessage
+        /// and remove the command.
+        /// </summary>
+        /// <param name="n">Node with the command infos</param>
+        /// <param name="computer">Current flightcomputer</param>
+        /// <returns>true - loaded successfull</returns>
+        public override bool Load(ConfigNode n, FlightComputer computer)
+        {
+            try
+            {
+                if(base.Load(n, computer))
+                {
+                    // try loading the reflectionType
+                    this.getReflectionType(this.ReflectionType);
+                    return true;
+                }
+            }
+            catch(Exception)
+            {
+                RTUtil.ScreenMessage(string.Format("Mod '{0}' not found. Queued command '{1}' will be removed.", this.Executor, this.ShortName));
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Prepare the data to pass back to the mod.
+        /// </summary>
+        /// <returns>ConfigNode to pass over to the reflection methods</returns>
+        private ConfigNode prepareDataForExternalMod()
+        {
+            ConfigNode externalData = ConfigNode.CreateConfigFromObject(this);
+            externalData.AddValue("AbortCommand",this.AbortCommand);
+
+            return externalData;
+        }
+
+        /// <summary>
+        /// Calls the rflection method.
+        /// </summary>
+        /// <param name="reflectionMember">Name of the reflection method</param>
+        /// <returns>Object from the invoked reflection method</returns>
+        private object callReflectionMember(string reflectionMember)
+        {
+            Type externalType = this.getReflectionType(this.ReflectionType);
+            var result = externalType.InvokeMember(reflectionMember, BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static, null, null, new System.Object[] { this.prepareDataForExternalMod() });
+            return result;
+        }
+
+        /// <summary>
+        /// Trys to load the reflectionType. Throws an exception if we can't
+        /// find the type.
+        /// </summary>
+        /// <param name="reflectionType">Type to load</param>
+        /// <returns>loaded type</returns>
+        private Type getReflectionType(string reflectionType)
+        {
+            Type type = Type.GetType(reflectionType);
+            if (type == null) throw new NullReferenceException();
+
+            return type;
+        }
         
     }
 }
-
-//Example method from Action Groups Extended to pass configNode to Remotetech. Ref: https://github.com/SirDiazo/AGExt/blob/master/AGExt/Flight.cs#L1556
-//
-//public void AGXActivateGroup(ConfigNode externalData)
-//        {
-//            Type calledType = Type.GetType("ActionGroupsExtended.AGExtExternal, AGExt");
-//           calledType.InvokeMember("AGXReceiveData", BindingFlags.InvokeMethod | BindingFlags.Public | BindingFlags.Static, null, null, new System.Object[] { externalData });
-//        }
-//}
-//}
-
-//Example Method in AGX to receive data node back from Remtotech. Ref: https://github.com/SirDiazo/AGExt/blob/master/AGExt/External.cs#L584
-
-//public static void RTDataReceive(ConfigNode node) //receive data back from RT
-//        {
-//            Debug.Log("AGX Call: RemoteTechCallback");
-//            if (HighLogic.LoadedSceneIsFlight)
-//            {
-//                if (FlightGlobals.ActiveVessel.rootPart.flightID == Convert.ToUInt32(node.GetValue("FlightID")))
-//                {
-
-//                    AGXFlight.ActivateActionGroupActivation(Convert.ToInt32(node.GetValue("Group")), Convert.ToBoolean(node.GetValue("Force")), Convert.ToBoolean(node.GetValue("ForceDir")));
-                    
-//                }
-//                else
-//                {
-//                    AGXOtherVessel otherVsl = new AGXOtherVessel(Convert.ToUInt32(node.GetValue("FlightID")));
-//                    otherVsl.ActivateActionGroupActivation(Convert.ToInt32(node.GetValue("Group")), Convert.ToBoolean(node.GetValue("Force")), Convert.ToBoolean(node.GetValue("ForceDir")));
-//                }
-//            }
-//            else
-//            {
-//                ScreenMessages.PostScreenMessage("AGX Action Not Activated, Remotetech passed invalid vessel", 10F, ScreenMessageStyle.UPPER_CENTER);
-                
-//            }
-//        }

--- a/src/RemoteTech/FlightComputer/Commands/ICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ICommand.cs
@@ -18,6 +18,6 @@ namespace RemoteTech.FlightComputer.Commands
         void Abort();
         /// 
         void Save(ConfigNode n, FlightComputer fc);
-        void Load(ConfigNode n, FlightComputer fc);
+        bool Load(ConfigNode n, FlightComputer fc);
     }
 }

--- a/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
@@ -184,20 +184,25 @@ namespace RemoteTech.FlightComputer.Commands
         /// </summary>
         /// <param name="n">Node with the command infos</param>
         /// <param name="fc">Current flightcomputer</param>
-        public override void Load(ConfigNode n, FlightComputer fc)
+        /// <returns>true - loaded successfull</returns>
+        public override bool Load(ConfigNode n, FlightComputer fc)
         {
-            base.Load(n,fc);
-            if(n.HasValue("NodeIndex"))
+            if(base.Load(n,fc))
             {
-                this.NodeIndex = int.Parse(n.GetValue("NodeIndex"));
-                RTLog.Notify("Trying to get Maneuver {0}", this.NodeIndex);
-                if (this.NodeIndex >= 0)
+                if(n.HasValue("NodeIndex"))
                 {
-                    // Set the ManeuverNode into this command
-                    this.Node = fc.Vessel.patchedConicSolver.maneuverNodes[this.NodeIndex];
-                    RTLog.Notify("Found Maneuver {0} with {1} dV", this.NodeIndex, this.Node.DeltaV);
+                    this.NodeIndex = int.Parse(n.GetValue("NodeIndex"));
+                    RTLog.Notify("Trying to get Maneuver {0}", this.NodeIndex);
+                    if (this.NodeIndex >= 0)
+                    {
+                        // Set the ManeuverNode into this command
+                        this.Node = fc.Vessel.patchedConicSolver.maneuverNodes[this.NodeIndex];
+                        RTLog.Notify("Found Maneuver {0} with {1} dV", this.NodeIndex, this.Node.DeltaV);
+                    }
                 }
             }
+
+            return false;
         }
 
         /// <summary>

--- a/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
@@ -57,29 +57,33 @@ namespace RemoteTech.FlightComputer.Commands
         /// </summary>
         /// <param name="n">Node with the command infos</param>
         /// <param name="fc">Current flightcomputer</param>
-        public override void Load(ConfigNode n, FlightComputer fc)
+        /// <returns>true - loaded successfull</returns>
+        public override bool Load(ConfigNode n, FlightComputer fc)
         {
-            base.Load(n, fc);
-
-            switch (TargetType)
+            if(base.Load(n, fc))
             {
-                case "Vessel":
-                    {
-                        Guid Vesselid = new Guid(TargetId);
-                        Target = FlightGlobals.Vessels.Where(v => v.id == Vesselid).FirstOrDefault();
-                        break;
-                    }
-                case "CelestialBody":
-                    {
-                        Target = FlightGlobals.Bodies.ElementAt(int.Parse(TargetId));
-                        break;
-                    }
-                default:
-                    {
-                        Target = null;
-                        break;
-                    }
+                switch (TargetType)
+                {
+                    case "Vessel":
+                        {
+                            Guid Vesselid = new Guid(TargetId);
+                            Target = FlightGlobals.Vessels.Where(v => v.id == Vesselid).FirstOrDefault();
+                            break;
+                        }
+                    case "CelestialBody":
+                        {
+                            Target = FlightGlobals.Bodies.ElementAt(int.Parse(TargetId));
+                            break;
+                        }
+                    default:
+                        {
+                            Target = null;
+                            break;
+                        }
+                }
+                return true;
             }
+            return false;
         }
 
         /// <summary>

--- a/src/RemoteTech/FlightComputer/EventCommand.cs
+++ b/src/RemoteTech/FlightComputer/EventCommand.cs
@@ -55,53 +55,54 @@ namespace RemoteTech.FlightComputer
         /// <summary>
         /// Load infos into this object and create a new BaseEvent
         /// </summary>
-        public override void Load(ConfigNode n, FlightComputer fc)
+        /// <returns>true - loaded successfull</returns>
+        public override bool Load(ConfigNode n, FlightComputer fc)
         {
-            base.Load(n, fc);
-
-            // deprecated since 1.6.2, we need this for upgrading from 1.6.x => 1.6.2
-            int PartId = 0;
+            if(base.Load(n, fc))
             {
-                if (n.HasValue("PartId"))
-                    PartId = int.Parse(n.GetValue("PartId"));
-            }
-
-            if (n.HasValue("flightID"))
-                this.flightID = uint.Parse(n.GetValue("flightID"));
-                        
-            this.Module = n.GetValue("Module");
-            this.GUIName = n.GetValue("GUIName");
-            this.Name = n.GetValue("Name");
-
-            RTLog.Notify("Try to load an EventCommand from persistent with {0},{1},{2},{3},{4}",
-                         PartId, this.flightID, this.Module, this.GUIName, this.Name);
-
-            Part part = null;
-            var partlist = FlightGlobals.ActiveVessel.parts;
-
-            if (this.flightID == 0)
-            {
-                // only look with the partid if we've enough parts
-                if (PartId < partlist.Count)
-                    part = partlist.ElementAt(PartId);
-            }
-            else
-            {
-                part = partlist.Where(p => p.flightID == this.flightID).FirstOrDefault();
-            }
-
-            if (part != null)
-            {
-                PartModule partmodule = part.Modules[Module];
-                if (partmodule != null)
+                // deprecated since 1.6.2, we need this for upgrading from 1.6.x => 1.6.2
+                int PartId = 0;
                 {
-                    BaseEventList eventlist = new BaseEventList(part, partmodule);
-                    if (eventlist.Count > 0)
-                    {
-                        this.BaseEvent = eventlist.Where(ba => (ba.GUIName == this.GUIName || ba.name == this.Name)).FirstOrDefault();
-                    }
+                    if (n.HasValue("PartId"))
+                        PartId = int.Parse(n.GetValue("PartId"));
                 }
+
+                if (n.HasValue("flightID"))
+                    this.flightID = uint.Parse(n.GetValue("flightID"));
+
+                this.Module = n.GetValue("Module");
+                this.GUIName = n.GetValue("GUIName");
+                this.Name = n.GetValue("Name");
+
+                RTLog.Notify("Try to load an EventCommand from persistent with {0},{1},{2},{3},{4}",
+                             PartId, this.flightID, this.Module, this.GUIName, this.Name);
+
+                Part part = null;
+                var partlist = FlightGlobals.ActiveVessel.parts;
+
+                if (this.flightID == 0)
+                {
+                    // only look with the partid if we've enough parts
+                    if (PartId < partlist.Count)
+                        part = partlist.ElementAt(PartId);
+                }
+                else
+                {
+                    part = partlist.Where(p => p.flightID == this.flightID).FirstOrDefault();
+                }
+
+                if (part == null) return false;
+
+                PartModule partmodule = part.Modules[Module];
+                if (partmodule == null) return false;
+
+                BaseEventList eventlist = new BaseEventList(part, partmodule);
+                if (eventlist.Count <= 0) return false;
+
+                this.BaseEvent = eventlist.Where(ba => (ba.GUIName == this.GUIName || ba.name == this.Name)).FirstOrDefault();
+                return true;
             }
+            return false;
         }
 
         /// <summary>

--- a/src/RemoteTech/UI/DebugWindow.cs
+++ b/src/RemoteTech/UI/DebugWindow.cs
@@ -413,24 +413,30 @@ namespace RemoteTech.UI
             }
             GUILayout.EndHorizontal();
             #endregion
-            #region API.ReceiveData
+            #region API.QueueCommandToFlightComputer
             GUILayout.BeginHorizontal();
             {
-                GUILayout.Label("API.ReceiveData; Guid: ", GUILayout.ExpandWidth(true));
+                GUILayout.Label("API.QueueCommandToFlightComputer; Guid: ", GUILayout.ExpandWidth(true));
                 this.ReceivDataVesselGuidInput = GUILayout.TextField(this.ReceivDataVesselGuidInput, GUILayout.Width(160));
                 if (GUILayout.Button("Run", GUILayout.Width(50)))
                 {
                     try
                     {
                         ConfigNode dataNode = new ConfigNode();
-                        dataNode.AddValue("Description", "Debug ReceiveData");
-                        dataNode.AddValue("ShortName", "Debug-Short");
-                        dataNode.AddValue("ReflectionGetType", "RemoteTech.UI.DebugWindow");
-                        dataNode.AddValue("ReflectionInvokeMember", "ReceiveData");
-                        dataNode.AddValue("GUIDString", this.ReceivDataVesselGuidInput);
-                        RemoteTech.API.API.ReceiveData(dataNode);
 
-                        RTLog.Verbose("API.ReceiveData({0})", this.currentLogLevel, dataNode);
+                        dataNode.AddValue("Executor", "RemoteTech");
+                        dataNode.AddValue("QueueLabel", "Receive Data");
+                        dataNode.AddValue("ActiveLabel", "Receiveing Data ...");
+                        dataNode.AddValue("ShortLabel", "Receive Data");
+                        dataNode.AddValue("ReflectionType", "RemoteTech.UI.DebugWindow");
+                        dataNode.AddValue("ReflectionPopMethod", "ReceiveDataPop");
+                        dataNode.AddValue("ReflectionExecuteMethod", "ReceiveDataExec");
+                        dataNode.AddValue("ReflectionAbortMethod", "ReceiveDataAbort");
+                        dataNode.AddValue("GUIDString", this.ReceivDataVesselGuidInput);
+
+                        var result = RemoteTech.API.API.QueueCommandToFlightComputer(dataNode);
+
+                        RTLog.Verbose("API.QueueCommandToFlightComputer(ConfigNode) = {0}", this.currentLogLevel, result);
                     }
                     catch (Exception ex)
                     {
@@ -509,12 +515,26 @@ namespace RemoteTech.UI
         }
 
         /// <summary>
-        /// This method is needed as a callback function for the API.ReceiveData
+        /// This method is needed as a callback function for the API.QueueCommandToFlightComputer
         /// </summary>
         /// <param name="data">data passed from the flightcomputer</param>
-        public static void ReceiveData(ConfigNode data)
+        public static bool ReceiveDataPop(ConfigNode data)
         {
-            RTLog.Verbose("Received Data via Api.ReceiveData with {0}", RTLogLevel.API, data);
+            RTLog.Verbose("Received Data via Api.ReceiveData", RTLogLevel.API);
+            RTLog.Notify("Data: {0}",data);
+            return true;
+        }
+        public static bool ReceiveDataExec(ConfigNode data)
+        {
+            RTLog.Verbose("Received Data via Api.ReceiveDataExec", RTLogLevel.API);
+            RTLog.Notify("Data: {0}", data);
+            
+            return bool.Parse(data.GetValue("AbortCommand"));
+        }
+        public static void ReceiveDataAbort(ConfigNode data)
+        {
+            RTLog.Verbose("Aborting via Api.ReceiveDataAbort", RTLogLevel.API);
+            RTLog.Notify("Data: {0}", data);
         }
     }
 }


### PR DESCRIPTION
- changed the name from `Api.ReceiveData` to `Api.QueueCommandToFlightComputer`
- The `Api.QueueCommandToFlightComputer` will now return a status if the command was queued successfull
- Changed some values for the parameter of the `Api.QueueCommandToFlightComputer`. Minimum values are now `GUIDString`, `Executor` and `ReflectionType`. Also added a value for the execution
and abort-method.
- fixed a load/save issue for the `ExternalApiCommand`
- also changed the return value of the `ICommand.Load` from void to bool, to determine if the loaded command was successfull or not, before enqueuing to the computer.

Ref task #233