### PR TITLE
Small fixes

### DIFF
--- a/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/AbstractCommand.cs
@@ -39,15 +39,14 @@ namespace RemoteTech.FlightComputer.Commands
         /// <summary>
         /// Save the basic informations for every command.
         /// </summary>
-        /// <param name="n">Node to save in</param>
-        /// <param name="fc">Current flightcomputer</param>
-        public virtual void Save(ConfigNode n, FlightComputer fc)
+        /// <param name="node">Node to save in</param>
+        /// <param name="computer">Current flightcomputer</param>
+        public virtual void Save(ConfigNode node, FlightComputer computer)
         {
-            ConfigNode save = new ConfigNode(this.GetType().Name);
             try
             {
                 // try to serialize 'this'
-                ConfigNode.CreateConfigFromObject(this, 0, save);
+                ConfigNode.CreateConfigFromObject(this, 0, node);
             }
             catch (Exception) {}
 
@@ -58,9 +57,8 @@ namespace RemoteTech.FlightComputer.Commands
                 TimeStamp = RTUtil.GameTime;
             }
 
-            save.AddValue("TimeStamp", TimeStamp);
-            save.AddValue("ExtraDelay", ExtraDelay);
-            n.AddNode(save);
+            node.AddValue("TimeStamp", TimeStamp);
+            node.AddValue("ExtraDelay", ExtraDelay);
         }
 
         /// <summary>

--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -489,11 +489,19 @@ namespace RemoteTech.FlightComputer
 
             foreach (KeyValuePair<int, ICommand> cmd in mActiveCommands)
             {
-                cmd.Value.Save(ActiveCommands, this);
+                // Save each active command on his own node
+                ConfigNode activeCommandNode = new ConfigNode(cmd.Value.GetType().Name);
+                cmd.Value.Save(activeCommandNode, this);
+                ActiveCommands.AddNode(activeCommandNode);
             }
 
             foreach (ICommand cmd in mCommandQueue)
-                cmd.Save(Commands, this);
+            {
+                // Save each command on his own node
+                ConfigNode commandNode = new ConfigNode(cmd.GetType().Name);
+                cmd.Save(commandNode, this);
+                Commands.AddNode(commandNode);
+            }
 
             ConfigNode FlightNode = new ConfigNode("FlightComputer");
             FlightNode.AddValue("TotalDelay", TotalDelay);

--- a/src/RemoteTech/UI/DebugWindow.cs
+++ b/src/RemoteTech/UI/DebugWindow.cs
@@ -433,6 +433,8 @@ namespace RemoteTech.UI
                         dataNode.AddValue("ReflectionExecuteMethod", "ReceiveDataExec");
                         dataNode.AddValue("ReflectionAbortMethod", "ReceiveDataAbort");
                         dataNode.AddValue("GUIDString", this.ReceivDataVesselGuidInput);
+                        dataNode.AddValue("YourData1", "RemoteTech");
+                        dataNode.AddValue("YourDataN", "TechRemote");
 
                         var result = RemoteTech.API.API.QueueCommandToFlightComputer(dataNode);
 


### PR DESCRIPTION
I changed the saving method for each active and queued command. We always passed the complete `flighcomputer`-Node to each command for saving. So this can cause problems by saving a command-data to his own node.
The `ExternalApiCommand` will now save the passed externalData ConfigNode from the API call to the persistent correctly.

Ref task: #233