### PR TITLE
Add option to allow control of unmanned ships without a connection

### DIFF
--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -39,6 +39,7 @@ namespace RemoteTech.FlightComputer
                 var satellite = RTCore.Instance.Network[SignalProcessor.Guid];
                 if (satellite != null && satellite.HasLocalControl) return 0.0;
                 var connection = RTCore.Instance.Network[satellite];
+				if (RTSettings.Instance.EnableNetworkOnlyMode && !connection.Any ()) return 0.0;
                 if (!connection.Any()) return Double.PositiveInfinity;
                 return connection.Min().Delay;
             }
@@ -53,7 +54,9 @@ namespace RemoteTech.FlightComputer
                 var status = State.Normal;
                 if (!SignalProcessor.Powered) status |= State.OutOfPower;
                 if (!SignalProcessor.IsMaster) status |= State.NotMaster;
-                if (!connection.Any()) status |= State.NoConnection;
+				if (!RTSettings.Instance.EnableNetworkOnlyMode) {
+					if (!connection.Any ()) status |= State.NoConnection;
+				}
                 if (Vessel.packed) status |= State.Packed;
                 return status;
             }

--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using UnityEngine;
@@ -26,7 +26,9 @@ namespace RemoteTech.FlightComputer
             {
                 var satellite = RTCore.Instance.Network[SignalProcessor.Guid];
                 var connection = RTCore.Instance.Network[satellite];
-                return (satellite != null && satellite.HasLocalControl) || (SignalProcessor.Powered && connection.Any());
+                return (satellite != null && satellite.HasLocalControl) || 
+		       (SignalProcessor.Powered && connection.Any()) || 
+		       (SignalProcessor.Powered && RTSettings.Instance.EnableNetworkOnlyMode);
             }
         }
 

--- a/src/RemoteTech/Modules/ModuleSPU.cs
+++ b/src/RemoteTech/Modules/ModuleSPU.cs
@@ -111,7 +111,7 @@ namespace RemoteTech.Modules
                 return State.ParentDefect;
             }
 
-            if (Satellite == null || !RTCore.Instance.Network[Satellite].Any())
+			if ((Satellite == null || !RTCore.Instance.Network[Satellite].Any()) && !RTSettings.Instance.EnableNetworkOnlyMode)
             {
                 return State.NoConnection;
             }
@@ -134,7 +134,14 @@ namespace RemoteTech.Modules
                     break;
                 case State.ParentDefect:
                 case State.NoConnection:
-                    GUI_Status = "No connection.";
+				    if (RTSettings.Instance.EnableNetworkOnlyMode) 
+					{
+						GUI_Status = "Network Only Mode";
+					} 
+					else 
+					{
+						GUI_Status = "No connection.";
+					}
                     break;
             }
         }

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -28,6 +28,7 @@ namespace RemoteTech
         [Persistent] public float SpeedOfLight = 3e8f;
         [Persistent] public MapFilter MapFilter = MapFilter.Path | MapFilter.Omni | MapFilter.Dish;
         [Persistent] public bool EnableSignalDelay = true;
+        [Persistent] public bool EnableNetworkOnlyMode = false;
         [Persistent] public RangeModel.RangeModel RangeModelType = RangeModel.RangeModel.Standard;
         [Persistent] public double MultipleAntennaMultiplier = 0.0;
         [Persistent] public bool ThrottleTimeWarp = true;

--- a/src/RemoteTech/UI/TimeWarpDecorator.cs
+++ b/src/RemoteTech/UI/TimeWarpDecorator.cs
@@ -61,7 +61,14 @@ namespace RemoteTech.UI
                         return "Connected";
                     }                    
                 }
-                return "No Connection";
+				if (RTSettings.Instance.EnableNetworkOnlyMode) 
+				{
+					return "Network Only Mode";
+				} 
+				else 
+				{
+					return "No Connection";
+				}
             }
         }
 


### PR DESCRIPTION
It adds a config option (defaults to off) that turns on a network only mode, where it bypasses the connection check (but keeps the powered check).

A few people I've talked to had explained that their enjoyment of remotetech came from the network building aspect, not the delay or control loss aspect.