### PR TITLE
Fixed thrust calculation

### DIFF
--- a/src/RemoteTech/FlightComputer/FlightCore.cs
+++ b/src/RemoteTech/FlightComputer/FlightCore.cs
@@ -152,15 +152,6 @@ namespace RemoteTech.FlightComputer
                 thrust += (double)pm.maxThrust * (pm.thrustPercentage / 100);
             }
 
-            foreach (var pm in v.parts.SelectMany(p => p.FindModulesImplementing<ModuleEnginesFX>()))
-            {
-                // Notice: flameout is only true if you try to perform with this engine not before
-                if (!pm.EngineIgnited || pm.flameout) continue;
-                // check for the needed propellant before changing the total thrust
-                if (!FlightCore.hasPropellant(pm.propellants)) continue;
-                thrust += (double)pm.maxThrust * (pm.thrustPercentage / 100);
-            }
-
             return thrust;
         }
     }
@@ -436,16 +427,6 @@ namespace RemoteTech.FlightComputer
                 bool engineFound = false;
                 {
                     ModuleEngines engine = p.Modules.OfType<ModuleEngines>().FirstOrDefault();
-                    if (engine != null)
-                    {
-                        if (!engine.isOperational)
-                            continue;
-                        engineFound = true;
-                        maxThrust = engine.maxThrust;
-                    }
-                }
-                {
-                    ModuleEnginesFX engine = p.Modules.OfType<ModuleEnginesFX>().FirstOrDefault();
                     if (engine != null)
                     {
                         if (!engine.isOperational)


### PR DESCRIPTION
On KSP 1.0 the ModuleEngineFX is now derived from the ModuleEngine class. Thats why we don't need two loops to calculate the thrust and torque for each class.

Fixes #399 