### PR TITLE
Correct sorted commands

### DIFF
--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -361,7 +361,7 @@ namespace RemoteTech.FlightComputer
 
             List<ICommand> backupList = mCommandQueue;
             // sort the backup queue
-            backupList = backupList.OrderBy(s => (s.TimeStamp + s.ExtraDelay)).ToList();
+            backupList = backupList.OrderBy(s => (s.Delay + s.ExtraDelay)).ToList();
             // clear the old queue
             mCommandQueue.Clear();
 


### PR DESCRIPTION
We should sort by the `Delay` value and not the `timestamp`, because the `timestamp = GameTime+SignalDelay` after adding a command and the timestamp value stays always on this value. For a maneuver command we set the `timestamp` value to the burn point. I can't reproduce issue #407 with this change anymore. So i think thats ok.

Fixes #407