### PR TITLE
No throttling back on phys warp

### DIFF
--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -237,7 +237,7 @@ namespace RemoteTech.FlightComputer
             if (mCommandQueue.Count > 0)
             {
                 // Can come out of time warp even if ship unpowered; workaround for KSP 0.24 power consumption bug
-                if (RTSettings.Instance.ThrottleTimeWarp && TimeWarp.CurrentRate > 1.0f)
+                if (RTSettings.Instance.ThrottleTimeWarp && TimeWarp.CurrentRate > 4.0f)
                 {
                     var time = TimeWarp.deltaTime;
                     foreach (var dc in mCommandQueue.TakeWhile(c => c.TimeStamp <= RTUtil.GameTime + (2 * time + 1.0)))


### PR DESCRIPTION
There is no need to throttle back the timewarp on physic warp.

Closes #357