### PR TITLE
Catch exceptions for BaseEvents

### DIFF
--- a/src/RemoteTech/FlightComputer/EventCommand.cs
+++ b/src/RemoteTech/FlightComputer/EventCommand.cs
@@ -37,7 +37,18 @@ namespace RemoteTech.FlightComputer
         public override bool Pop(FlightComputer f)
         {
             if (this.BaseEvent != null)
-                this.BaseEvent.Invoke();
+            {
+                try
+                {
+                    // invoke the baseevent
+                    this.BaseEvent.Invoke();
+                }
+                catch (Exception invokeException)
+                {
+                    RTLog.Notify("BaseEvent invokeException by '{0}' with message: {1}",
+                                 RTLogLevel.LVL1, this.BaseEvent.guiName, invokeException.Message);
+                }
+            }
             
             return false;
         }


### PR DESCRIPTION
If someone throws an exception on a BaseEvent the flight computer tries to invoke over and over. Thats why i catch the exception, make a log entry and ignore the rest.

Fixes #412 