### PR TITLE
Keep the roll

### DIFF
--- a/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
@@ -89,7 +89,7 @@ namespace RemoteTech.FlightComputer.Commands
             var forward = Node.GetBurnVector(computer.Vessel.orbit).normalized;
             var up = (computer.SignalProcessor.Body.position - computer.SignalProcessor.Position).normalized;
             var orientation = Quaternion.LookRotation(forward, up);
-            FlightCore.HoldOrientation(ctrlState, computer, orientation);
+            FlightCore.HoldOrientation(ctrlState, computer, orientation, true);
 
             // This represents the theoretical acceleration but is off by a few m/s^2, probably because some parts are partially physicsless
             double thrustToMass = (FlightCore.GetTotalThrust(computer.Vessel) / computer.Vessel.GetTotalMass());


### PR DESCRIPTION
I'm not good with Quaternions thats why i use the predefined variable `fixedRoll` by Starstrider42. I pass a new parameter `ignoreRoll` to the `HoldOrientation` method to pass it to the `SteeringHelper`. The Roll will no more fixed for: ManeuverNodes, Orbit and Surface maneuvers.

Fixes #340 