### PR TITLE
Add RemoteTech_CactEye_Probes.cfg to fix #429

### DIFF
--- a/GameData/RemoteTech/RemoteTech_CactEye_Probes.cfg
+++ b/GameData/RemoteTech/RemoteTech_CactEye_Probes.cfg
@@ -1,0 +1,19 @@
+// Support for stock probe cores
+// Original config by xZise
+
+@PART[probeCoreSlim]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}


### PR DESCRIPTION
In the CactEye mod a new probe core the Smobodobodyne SLIM has been added. This adds the appropriate RemoteTech functionality.