### PR TITLE
Changed the body determination for a MissionCtrlSat

### DIFF
--- a/src/RemoteTech/NetworkRenderer.cs
+++ b/src/RemoteTech/NetworkRenderer.cs
@@ -90,9 +90,8 @@ namespace RemoteTech
 
                     if (s is MissionControlSatellite && RTSettings.Instance.HideGroundStationsBehindBody)
                     {
-                        CelestialBody kerbin = FlightGlobals.Bodies.Find(body => body.name == "Kerbin");
                         // Hide the current ISatellite if it is behind its body
-                        if (IsOccluded(s.Position, kerbin))
+                        if (IsOccluded(s.Position, s.Body))
                             showOnMapview = false;
                     }
 


### PR DESCRIPTION
I changed the `CelestialBody` Parameter for the `IsOccluded` call to the satellites body

fixes #440 