### PR TITLE
Fixed loading animation

### DIFF
--- a/src/RemoteTech/Modules/ModuleRTAntenna.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntenna.cs
@@ -508,19 +508,16 @@ namespace RemoteTech.Modules
         {
             var modules = new List<IScalarModule>();
             if (indices == null) return modules;
-            foreach (int i in indices)
+
+            foreach (PartModule partModule in this.part.Modules)
             {
-                var item = base.part.Modules[i] as IScalarModule;
-                if (item != null)
-                {
-                    item.SetUIWrite(showUI);
-                    item.SetUIRead(showUI);
-                    modules.Add(item);
-                }
-                else
-                {
-                    RTLog.Notify("ModuleRTAntenna: Part Module {0} doesn't implement IScalarModule", part.Modules[i].name);
-                }
+                var item = partModule as IScalarModule;
+                // skip this module if it has no IScalarModule
+                if (item == null) continue;
+                
+                item.SetUIWrite(showUI);
+                item.SetUIRead(showUI);
+                modules.Add(item);
             }
             return modules;
         }

--- a/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
@@ -187,6 +187,9 @@ namespace RemoteTech.Modules
             mTransmitter = null;
         }
 
+        /// <summary>
+        /// Deprecated?
+        /// </summary>
         private List<IScalarModule> FindFxModules(int[] indices, bool showUI)
         {
             var modules = new List<IScalarModule>();


### PR DESCRIPTION
The method `FindFxModules` only looks into the first module and if this isn't a `iScalarModule` the animation will not be loaded. The parameter `indices` are always empty respectively with one element. (not sure why)

fixes #213 