### PR TITLE
Add an API to get the connection status of an individual antenna

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -1,4 +1,5 @@
-﻿using RemoteTech.RangeModel;
+﻿using RemoteTech.Modules;
+using RemoteTech.RangeModel;
 using RemoteTech.SimpleTypes;
 using System;
 using System.Collections.Generic;
@@ -79,6 +80,14 @@ namespace RemoteTech.API
             var connectedToKerbin = RTCore.Instance.Network[satellite].Any(r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Goal.Guid));
             RTLog.Verbose("Flight: {0} Has Connection to Kerbin: {1}", RTLogLevel.API, id, connectedToKerbin);
             return connectedToKerbin;
+        }
+
+        public static bool AntennaHasConnection(Part part)
+        {
+            if (RTCore.Instance == null) return false;
+            var antennaModules = part.Modules.OfType<IAntenna>();
+
+            return antennaModules.Any(m => m.Connected);
         }
 
         public static double GetShortestSignalDelay(Guid id)

--- a/src/RemoteTech/IAntenna.cs
+++ b/src/RemoteTech/IAntenna.cs
@@ -8,6 +8,7 @@ namespace RemoteTech
         Guid Guid { get; }
         bool Activated { get; set; }
         bool Powered { get; }
+        bool Connected { get; }
         bool CanTarget { get; }
         Guid Target { get; set; }
         float Dish { get; }

--- a/src/RemoteTech/Modules/MissionControlAntenna.cs
+++ b/src/RemoteTech/Modules/MissionControlAntenna.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Linq;
 
 namespace RemoteTech.Modules
 {
@@ -11,6 +12,7 @@ namespace RemoteTech.Modules
         Guid IAntenna.Guid { get { return Parent.Guid; } }
         String IAntenna.Name { get { return "Dummy Antenna"; } }
         bool IAntenna.Powered { get { return true; } }
+        public bool Connected { get { return RTCore.Instance.Network.Graph [((IAntenna)this).Guid].Any (l => l.Interfaces.Contains (this)); } }
         bool IAntenna.Activated { get { return true; } set { return; } }
         float IAntenna.Consumption { get { return 0.0f; } }
         bool IAntenna.CanTarget { get { return false; } }

--- a/src/RemoteTech/Modules/ModuleRTAntenna.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntenna.cs
@@ -15,6 +15,7 @@ namespace RemoteTech.Modules
         public String Name { get { return part.partInfo.title; } }
         public Guid Guid { get { return mRegisteredId; } }
         public bool Powered { get { return IsRTPowered; } }
+        public bool Connected { get { return RTCore.Instance.Network.Graph [Guid].Any (l => l.Interfaces.Contains (this)); } }
         public bool Activated { get { return IsRTActive; } set { SetState(value); } }
         public bool CanAnimate { get { return mDeployFxModules.Count > 0; } }
         public bool AnimClosed { get { return mDeployFxModules.Any(fx => fx.GetScalar <= 0.1f                        ); } }
@@ -22,6 +23,7 @@ namespace RemoteTech.Modules
         public bool AnimOpen   { get { return mDeployFxModules.Any(fx =>                         fx.GetScalar >= 0.9f); } }
 
         public bool CanTarget { get { return Mode1DishRange != -1.0f; } }
+
         public Guid Target
         {
             get { return RTAntennaTarget; }
@@ -118,6 +120,7 @@ namespace RemoteTech.Modules
         {
             Off,
             Operational,
+            Connected,
             NoResources,
             Malfunction,
         }
@@ -386,7 +389,7 @@ namespace RemoteTech.Modules
             float resourceAmount = part.RequestResource("ElectricCharge", resourceRequest);
             if (resourceAmount < resourceRequest * 0.9) return State.NoResources;
             
-            return State.Operational;
+            return Connected ? State.Connected : State.Operational;
         }
 
         private void FixedUpdate()
@@ -399,6 +402,10 @@ namespace RemoteTech.Modules
                     break;
                 case State.Operational:
                     GUI_Status = Mode1Name;
+                    IsRTPowered = true;
+                    break;
+                case State.Connected:
+                    GUI_Status = "Connected";
                     IsRTPowered = true;
                     break;
                 case State.NoResources:

--- a/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
@@ -13,6 +13,7 @@ namespace RemoteTech.Modules
         public String Name { get { return part.partInfo.title; } }
         public Guid Guid { get { return vessel.id; } }
         public bool Powered { get { return Activated; } }
+        public bool Connected { get { return RTCore.Instance.Network.Graph [Guid].Any (l => l.Interfaces.Contains (this)); } }
         public bool Activated { get { return Unlocked; } set { return; } }
         public bool Animating { get { return false; } }
 

--- a/src/RemoteTech/Modules/ProtoAntenna.cs
+++ b/src/RemoteTech/Modules/ProtoAntenna.cs
@@ -9,6 +9,7 @@ namespace RemoteTech.Modules
         public Guid Guid { get; private set; }
         public bool Powered { get; private set; }
         public bool Activated { get; set; }
+        public bool Connected { get { return RTCore.Instance.Network.Graph [Guid].Any (l => l.Interfaces.Contains (this)); } }
         public float Consumption { get; private set; }
 
         public bool CanTarget { get { return Dish != -1; } }


### PR DESCRIPTION
Adds `Connected` field to `IAntenna`. This is used to set the antenna status to 'Connected' instead of 'Operational' when antenna is connected. Adds `AntennaHasConnection` method to the API.

Fixes #365.