### PR TITLE
Clean up vessel target handling

### DIFF
--- a/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/TargetCommand.cs
@@ -26,14 +26,6 @@ namespace RemoteTech.FlightComputer.Commands
         public override bool Pop(FlightComputer f)
         {
             f.DelayedTarget = Target;
-            f.lastTarget = this;
-
-            if (Target != null && Target != FlightGlobals.fetch.VesselTarget)
-            {
-                // Switch the vessels target
-                FlightGlobals.fetch.SetVesselTarget(Target);
-            }
-
             return true;
         }
 

--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -207,7 +207,8 @@ namespace RemoteTech.FlightComputer
             updatePIDParameters();
 
             // Send updates for Target
-            if (FlightGlobals.fetch.VesselTarget != DelayedTarget && (mCommandQueue.FindLastIndex(c => (lastTarget = c as TargetCommand) != null)) == -1)
+            if (Vessel == FlightGlobals.ActiveVessel && FlightGlobals.fetch.VesselTarget != DelayedTarget &&
+                (mCommandQueue.FindLastIndex(c => (lastTarget = c as TargetCommand) != null)) == -1)
             {
                 Enqueue(TargetCommand.WithTarget(FlightGlobals.fetch.VesselTarget));
             }

--- a/src/RemoteTech/FlightComputer/FlightComputer.cs
+++ b/src/RemoteTech/FlightComputer/FlightComputer.cs
@@ -222,7 +222,8 @@ namespace RemoteTech.FlightComputer
             {
                 lastTarget = mCommandQueue[lastTargetIndex] as TargetCommand;
             }
-            else if (mActiveCommands[lastTarget.Priority] is TargetCommand)
+            else if (mActiveCommands.ContainsKey(lastTarget.Priority) &&
+                     mActiveCommands[lastTarget.Priority] is TargetCommand)
             {
                 lastTarget = mActiveCommands[lastTarget.Priority] as TargetCommand;
             }


### PR DESCRIPTION
Fixes a number of issues with how the flight computer handles vessel targeting:
- All vessels within physics range that were set to `TargetVelocity` or `TargetParallel` would set their attitude relative to the active vessel's target, instead of their own.
- Changing a vessel's target would have no effect while a `TargetCommand` was pending.
- Execution of a `TargetCommand` would overwrite the current target of whatever vessel happened to be active when the command was executed.