### PR TITLE
Asteroid Day probe core

### DIFF
--- a/GameData/RemoteTech/RemoteTech_Squad_Probes.cfg
+++ b/GameData/RemoteTech/RemoteTech_Squad_Probes.cfg
@@ -155,3 +155,20 @@
 		}
 	}
 }
+
+@PART[HECS2_ProbeCore]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}


### PR DESCRIPTION
Add default RemoteTech modules to the HECS2_ProbeCore, released as part of the Asteroid Day mod by Squad, RoverDude, and Arsonide.