### PR TITLE
Add Asteroid Day Parts

### DIFF
--- a/GameData/RemoteTech/RemoteTech_Squad_Antennas.cfg
+++ b/GameData/RemoteTech/RemoteTech_Squad_Antennas.cfg
@@ -91,3 +91,32 @@
 	
 	%MODULE[ModuleSPUPassive] {}
 }
+
+@PART[HighGainAntenna]:FOR[RemoteTech]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 25000000000
+		%EnergyCost = 1.04
+		%MaxQ = 6000
+		%DishAngle = 0.12
+		
+		%DeployFxModules = 0
+		%ProgressFxModules = 1
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.15
+			%PacketSize = 3
+			%PacketResourceCost = 20.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}

--- a/GameData/RemoteTech/RemoteTech_Squad_Probes.cfg
+++ b/GameData/RemoteTech/RemoteTech_Squad_Probes.cfg
@@ -155,3 +155,20 @@
 		}
 	}
 }
+
+@PART[HECS2_ProbeCore]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}


### PR DESCRIPTION
Add RemoteTech modules for the fairly new Asteroid Day parts. This is the second *official* mod from Squad, RoverDude, and Arsonide. It is available from http://kerbal.curseforge.com/ksp-mods/232196-asteroid-day

Went with standard configuration details for the probe core, and 25Gm range (with above-average power usage, dish angle, and transfer rates) for the antenna. 25Gm *almost* covers Eve's orbit, year-round, directly from Kerbin.