### PR TITLE
Dishes for MissionControl Antennas

### DIFF
--- a/src/RemoteTech/Modules/MissionControlAntenna.cs
+++ b/src/RemoteTech/Modules/MissionControlAntenna.cs
@@ -6,6 +6,9 @@ namespace RemoteTech.Modules
     public sealed class MissionControlAntenna : IAntenna
     {
         [Persistent] public float Omni = 75000000;
+        [Persistent] public float Dish = 0.0f;
+        [Persistent] public double CosAngle = 1.0;
+
         public ISatellite Parent { get; set; }
 
         float IAntenna.Omni { get { return Omni; } }
@@ -16,9 +19,9 @@ namespace RemoteTech.Modules
         bool IAntenna.Activated { get { return true; } set { return; } }
         float IAntenna.Consumption { get { return 0.0f; } }
         bool IAntenna.CanTarget { get { return false; } }
-        Guid IAntenna.Target { get { return Guid.Empty; } set { return; } }
-        float IAntenna.Dish { get { return 0.0f; } }
-        double IAntenna.CosAngle { get { return 1.0; } }
+        Guid IAntenna.Target { get { return new Guid(RTSettings.Instance.ActiveVesselGuid); } set { return; } }
+        float IAntenna.Dish { get { return Dish; } }
+        double IAntenna.CosAngle { get { return CosAngle; } }
 
         public void OnConnectionRefresh() { }
 


### PR DESCRIPTION
# Modders
- You can now configure a dish antenna to mission control. All mission control dishes are only pointed to the Active Vessel (thx to jdmj)

closes #472 