### PR TITLE
Format consumption fix

### DIFF
--- a/src/RemoteTech/Modules/ModuleRTAntenna.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntenna.cs
@@ -141,7 +141,7 @@ namespace RemoteTech.Modules
             }
             if (ShowEditor_EnergyReq && EnergyCost > 0)
             {
-                info.AppendFormat("Energy req.: {0}", RTUtil.FormatConsumption(EnergyCost * ConsumptionMultiplier)).AppendLine();
+                info.AppendFormat("ElectricCharge: {0}", RTUtil.FormatConsumption(EnergyCost * ConsumptionMultiplier)).AppendLine();
             }
 
             if (ShowEditor_DishAngle && CanTarget)

--- a/src/RemoteTech/RTUtil.cs
+++ b/src/RemoteTech/RTUtil.cs
@@ -139,11 +139,7 @@ namespace RemoteTech
         {
             String timeindicator = "sec";
 
-            if(consumption > 1)
-            {
-                // keep the values in seconds
-            }
-            else
+            if(consumption < 1)
             {
                 // minutes
                 consumption *= 60;

--- a/src/RemoteTech/RTUtil.cs
+++ b/src/RemoteTech/RTUtil.cs
@@ -137,7 +137,20 @@ namespace RemoteTech
 
         public static String FormatConsumption(double consumption)
         {
-            return consumption.ToString("F2") + " charge/s";
+            String timeindicator = "sec";
+
+            if(consumption > 1)
+            {
+                // keep the values in seconds
+            }
+            else
+            {
+                // minutes
+                consumption *= 60;
+                timeindicator = "min";
+            }
+            
+            return String.Format("{0:F2}/{1}.", consumption, timeindicator);
         }
 
         public static String FormatSI(double value, String unit)


### PR DESCRIPTION
For RSS/RO/RP-0 players the eletric consumption of the long antenna is displayed as 0.00/s because we've a formated string with F2 and for this antenna the consumption is 0.0015/s. We'll now tranform all consumptions lower than 1.00/s into minutes. I've also changed the label `Energy req.` into a more stock like label `ElectricCharge`. Also `s` to sec and min for minutes

fixes #487