### PR TITLE
Better editor infos

### DIFF
--- a/src/RemoteTech/Modules/ModuleRTAntenna.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntenna.cs
@@ -139,10 +139,6 @@ namespace RemoteTech.Modules
             {
                 info.AppendFormat("Dish range: {0} / {1}", RTUtil.FormatSI(Mode0DishRange * RangeMultiplier, "m"), RTUtil.FormatSI(Mode1DishRange * RangeMultiplier, "m")).AppendLine();
             }
-            if (ShowEditor_EnergyReq && EnergyCost > 0)
-            {
-                info.AppendFormat("ElectricCharge: {0}", RTUtil.FormatConsumption(EnergyCost * ConsumptionMultiplier)).AppendLine();
-            }
 
             if (ShowEditor_DishAngle && CanTarget)
             {
@@ -151,12 +147,18 @@ namespace RemoteTech.Modules
 
             if (IsRTActive)
             {
-                info.AppendLine("Activated by default");
+                info.AppendLine("<color=#89929B>Activated by default</color>");
             }
 
             if (MaxQ > 0)
             {
-                info.AppendLine("Snaps under high dynamic pressure");
+                info.AppendLine("<b><color=#FDA401>Snaps under high dynamic pressure</color></b>");
+            }
+
+            if (ShowEditor_EnergyReq && EnergyCost > 0)
+            {
+                info.AppendLine().Append("<b><color=#99ff00ff>Requires:</color></b>").AppendLine();
+                info.AppendFormat("<b>ElectricCharge: </b>{0}", RTUtil.FormatConsumption(EnergyCost * ConsumptionMultiplier)).AppendLine();
             }
 
             return info.ToString().TrimEnd(Environment.NewLine.ToCharArray());

--- a/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
@@ -71,8 +71,6 @@ namespace RemoteTech.Modules
             RTPacketResourceCost = 0.0f;
 
         public int[] mDeployFxModuleIndices, mProgressFxModuleIndices;
-//        private List<IScalarModule> mDeployFxModules = new List<IScalarModule>();
-//        private List<IScalarModule> mProgressFxModules = new List<IScalarModule>();
         public ConfigNode mTransmitterConfig;
         private IScienceDataTransmitter mTransmitter;
 

--- a/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
+++ b/src/RemoteTech/Modules/ModuleRTAntennaPassive.cs
@@ -1,9 +1,7 @@
 ﻿using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
-using UnityEngine;
 
 namespace RemoteTech.Modules
 {
@@ -27,7 +25,7 @@ namespace RemoteTech.Modules
         public Vector3d Position { get { return vessel.GetWorldPos3D(); } }
 
         private float RangeMultiplier { get { return RTSettings.Instance.RangeMultiplier; } }
-        private bool Unlocked { get { return ResearchAndDevelopment.GetTechnologyState(TechRequired) == RDTech.State.Available || TechRequired.Equals("None"); } }
+        private bool Unlocked { get { return RTUtil.IsTechUnlocked("RTPassiveAntennaTech"); } }
 
         [KSPField]
         public bool
@@ -248,31 +246,6 @@ namespace RemoteTech.Modules
         public override string ToString()
         {
             return String.Format("ModuleRTAntennaPassive(Name: {0}, Guid: {1}, Omni: {2})", Name, mRegisteredId, Omni);
-        }
-    }
-
-    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
-    public class ModuleRTAntennaPassive_ReloadPartInfo : MonoBehaviour
-    {
-        public void Start()
-        {
-            StartCoroutine(RefreshPartInfo());
-        }
-
-        private IEnumerator RefreshPartInfo()
-        {
-            yield return null;
-            foreach (var ap in PartLoader.LoadedPartsList.Where(ap => ap.partPrefab.Modules != null && ap.partPrefab.Modules.Contains("ModuleRTAntennaPassive")))
-            {
-                var new_info = new StringBuilder();
-                foreach (PartModule pm in ap.partPrefab.Modules)
-                {
-                    var info = pm.GetInfo();
-                    new_info.Append(info);
-                    if (info != String.Empty) new_info.AppendLine();
-                }
-                ap.moduleInfo = new_info.ToString().TrimEnd(Environment.NewLine.ToCharArray());
-            }
         }
     }
 }

--- a/src/RemoteTech/Modules/ModuleSPU.cs
+++ b/src/RemoteTech/Modules/ModuleSPU.cs
@@ -68,8 +68,7 @@ namespace RemoteTech.Modules
         {
             if (!ShowEditor_Type) return String.Empty;
             return IsRTCommandStation 
-                ? String.Format("Remote Command capable ({0}+ crew)", RTCommandMinCrew) 
-                : "Remote Control capable";
+                ? String.Format("Remote Command capable <color=#00FFFF>({0}+ crew)</color>", RTCommandMinCrew) : "Remote Control capable";
         }
 
         public override void OnStart(StartState state)

--- a/src/RemoteTech/RTPartInfoReloader.cs
+++ b/src/RemoteTech/RTPartInfoReloader.cs
@@ -1,0 +1,119 @@
+﻿using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using UnityEngine;
+
+namespace RemoteTech
+{
+    [KSPAddon(KSPAddon.Startup.EditorAny, false)]
+    class RTPartInfoReloader : MonoBehaviour
+    {
+        public void Start()
+        {
+            StartCoroutine(ReloadInfos());
+        }
+
+        private IEnumerator ReloadInfos()
+        {
+            yield return null;
+
+            List<AvailablePart> loadedParts = PartLoader.LoadedPartsList;
+            // find all RT parts
+            IEnumerable<AvailablePart> rtPartList = loadedParts.Where(part => part.partPrefab.Modules != null && (part.partPrefab.Modules.Contains("ModuleRTAntennaPassive") ||
+                                                                                                                  part.partPrefab.Modules.Contains("ModuleRTAntenna") ||
+                                                                                                                  part.partPrefab.Modules.Contains("ModuleSPU") ||
+                                                                                                                  part.partPrefab.Modules.Contains("ModuleSPUPassive")));
+
+            bool TechPerkResearched = RTUtil.IsTechUnlocked("RTPassiveAntennaTech");
+
+            foreach (var rtPart in rtPartList)
+            {
+                bool partHasTechPerk = rtPart.partPrefab.Modules.Contains("ModuleRTAntennaPassive");
+                bool techPerkRefreshed = false;
+
+                for (int i = rtPart.moduleInfos.Count - 1; i >= 0; i--)
+                {
+                    var info = rtPart.moduleInfos[i];
+
+                    String moduleName = info.moduleName;
+                    if (moduleName == "Technology Perk" || moduleName == "Antenna" || moduleName == "Signal Processor" )
+                    {
+                        String moduleClassName = String.Empty;
+                        if (moduleName == "Technology Perk")  moduleClassName = "ModuleRTAntennaPassive";
+                        if (moduleName == "Antenna")          moduleClassName = "ModuleRTAntenna";
+                        if (moduleName == "Signal Processor") moduleClassName = "ModuleSPU";
+
+                        // no moduleClassName found, skip to the next part
+                        if (moduleClassName == String.Empty) continue;
+
+                        // otherwise refresh the infos
+                        string new_infos = this.RefreshPartInfo(rtPart.partPrefab, moduleClassName);
+                        if (new_infos != String.Empty)
+                        {
+                            if (moduleName == "Technology Perk")
+                            {
+                                techPerkRefreshed = true;
+                            }
+                            info.info = new_infos;
+                        }
+                        else
+                        {
+                            // Remove this info block, should only be the Technology Perk
+                            rtPart.moduleInfos.RemoveAt(i);
+                        }
+                    }
+                }
+
+                // add a new info block for TechPerk
+                if (techPerkRefreshed == false && partHasTechPerk == true && TechPerkResearched == true)
+                {
+                    rtPart.moduleInfos.Add(this.CreateTechPerkInfoforPart(rtPart.partPrefab));
+                }
+            }
+        }
+
+        /// <summary>
+        /// This method creates a new Info-block for the <paramref name="part"/> and
+        /// the <paramref name="moduleClassName"/> and returns a string. If no info
+        /// is available the result is an empty string.
+        /// 
+        /// </summary>
+        /// <param name="part">Part to get the infos</param>
+        /// <param name="moduleClassName">module class name for the getInfo() call</param>
+        /// <returns>new info block</returns>
+        private String RefreshPartInfo(Part part, String moduleClassName)
+        {
+            String new_info = String.Empty;
+                
+            foreach (PartModule pm in part.Modules)
+            {
+                if (pm.moduleName == moduleClassName)
+                {
+                    new_info = pm.GetInfo();
+                }
+            }
+
+            return new_info;
+        }
+
+        /// <summary>
+        /// This method creates a new AvailablePart.ModuleInfo object with
+        /// the Technology Perk info block.
+        /// </summary>
+        /// <param name="part">Part to get the infos</param>
+        /// <returns></returns>
+        private AvailablePart.ModuleInfo CreateTechPerkInfoforPart(Part part)
+        {
+            // Get the infos for the TechPerk info block
+            string perk_infos = this.RefreshPartInfo(part, "ModuleRTAntennaPassive");
+
+            // creates a new info block
+            AvailablePart.ModuleInfo NewPerkInfo = new AvailablePart.ModuleInfo();
+            NewPerkInfo.info = perk_infos;
+            NewPerkInfo.moduleName = "Technology Perk";
+
+            return NewPerkInfo;
+        }
+    }
+}

--- a/src/RemoteTech/RTUtil.cs
+++ b/src/RemoteTech/RTUtil.cs
@@ -446,26 +446,18 @@ namespace RemoteTech
             return cachedField.Field = getter();
         }
 
-        // Thanks Fractal_UK!
+        
         public static bool IsTechUnlocked(string techid)
         {
             if (techid.Equals("None")) return true;
             try
             {
-                if (HighLogic.CurrentGame.Mode == Game.Modes.CAREER) return true;
-                string persistentfile = KSPUtil.ApplicationRootPath + "saves/" + HighLogic.SaveFolder + "/persistent.sfs";
-                ConfigNode config = ConfigNode.Load(persistentfile);
-                ConfigNode gameconf = config.GetNode("GAME");
-                ConfigNode[] scenarios = gameconf.GetNodes("SCENARIO");
-                foreach (ConfigNode scenario in scenarios.Where(s=> s.GetValue("name") != "ResearchAndDevelopment"))
-                {
-                    ConfigNode[] techs = scenario.GetNodes("Tech");
-                    if (techs.Any(technode => technode.GetValue("id") == techid))
-                    {
-                        return true;
-                    }
-                }
-                return false;
+                var availablePart = PartLoader.LoadedPartsList.Where(part => part.name.Contains(techid)).First();
+                if (availablePart == null) return false;
+
+                bool researched = ResearchAndDevelopment.PartModelPurchased(availablePart);
+
+                return researched;
             }
             catch (Exception)
             {

--- a/src/RemoteTech/RemoteTech.csproj
+++ b/src/RemoteTech/RemoteTech.csproj
@@ -95,6 +95,7 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Modules\ProtoAntenna.cs" />
     <Compile Include="RTCore.cs" />
+    <Compile Include="RTPartInfoReloader.cs" />
     <Compile Include="RTSettings.cs" />
     <Compile Include="RTSpaceCentre.cs" />
     <Compile Include="RTUtil.cs" />


### PR DESCRIPTION
- Added more colors to the editor part infos (more stock like)
- Refactored the unused method RTUtil::IsTechUnlocked(). Parsing the complete
`persistent.sfs` is way to much.
- Fixed an issue where the TechPerk is already available only if i
researched the node but without purchasing the TechPerk-Part it self
- Class ModuleRTAntennaPassive_ReloadPartInfo removed
- New class RTPartInfoReloader created

fixes #489