### PR TITLE
SetAntennaTarget API

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -1,4 +1,5 @@
 ﻿using RemoteTech.RangeModel;
+﻿using RemoteTech.Modules;
 using RemoteTech.SimpleTypes;
 using System;
 using System.Collections.Generic;
@@ -93,6 +94,58 @@ namespace RemoteTech.API
             var antennaModules = part.Modules.OfType<IAntenna>();
 
             return antennaModules.Any(m => m.Connected);
+        }
+
+        public static Guid GetAntennaTarget(Part part) {
+            ModuleRTAntenna module = part.Modules.OfType<ModuleRTAntenna>().First();
+
+            if (module == null)
+            {
+                throw new ArgumentException();
+            }
+
+            return module.Target;
+        }
+
+        public static void SetAntennaTarget(Part part, Guid id) {
+            ModuleRTAntenna module = part.Modules.OfType<ModuleRTAntenna>().First();
+
+            if (module == null)
+            {
+                throw new ArgumentException();
+            }
+
+            module.Target = id;
+        }
+
+        public static IEnumerable<string> GetGroundStations()
+        {
+            return RTSettings.Instance.GroundStations.Select(s => ((ISatellite)s).Name);
+        }
+
+        public static Guid GetGroundStationGuid(String name)
+        {
+            ISatellite groundStation = Array.Find(RTSettings.Instance.GroundStations, s => ((ISatellite)s).Name.Equals(name));
+
+            if (groundStation == null)
+            {
+                throw new ArgumentException();
+            }
+
+            return groundStation.Guid;
+        }
+
+        public static Guid GetCelestialBodyGuid(CelestialBody celestialBody)
+        {
+            return RTUtil.Guid(celestialBody);
+        }
+
+        public static Guid GetNoTargetGuid() {
+            return new Guid(RTSettings.Instance.NoTargetGuid);
+        }
+
+        public static Guid GetActiveVesselGuid() {
+            return new Guid(RTSettings.Instance.ActiveVesselGuid);
         }
 
         public static double GetShortestSignalDelay(Guid id)

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -101,7 +101,7 @@ namespace RemoteTech
         }
 
         /// <summary>
-        /// Stores the MapFilter, ActiveVesselGuid and RemoteTechEnabled Value for overriding
+        /// Stores the MapFilter, ActiveVesselGuid, NoTargetGuid and RemoteTechEnabled Value for overriding
         /// with third party settings
         /// </summary>
         public void backupFields()
@@ -109,6 +109,7 @@ namespace RemoteTech
             backupNode = new ConfigNode();
             backupNode.AddValue("MapFilter", MapFilter);
             backupNode.AddValue("ActiveVesselGuid", ActiveVesselGuid);
+            backupNode.AddValue("NoTargetGuid", NoTargetGuid);
             backupNode.AddValue("RemoteTechEnabled", RemoteTechEnabled);
         }
 

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -29,6 +29,7 @@ namespace RemoteTech
         [Persistent] public float ConsumptionMultiplier = 1.0f;
         [Persistent] public float RangeMultiplier = 1.0f;
         [Persistent] public String ActiveVesselGuid = "35b89a0d664c43c6bec8d0840afc97b2";
+        [Persistent] public String NoTargetGuid = Guid.Empty.ToString();
         [Persistent] public float SpeedOfLight = 3e8f;
         [Persistent] public MapFilter MapFilter = MapFilter.Path | MapFilter.Omni | MapFilter.Dish;
         [Persistent] public bool EnableSignalDelay = true;

--- a/src/RemoteTech/UI/AntennaFragment.cs
+++ b/src/RemoteTech/UI/AntennaFragment.cs
@@ -223,7 +223,7 @@ namespace RemoteTech.UI
             mSelection = new Entry()
             {
                 Text = "No Target",
-                Guid = Guid.Empty,
+                Guid = new Guid(RTSettings.Instance.NoTargetGuid),
                 Color = Color.white,
                 Depth = 0,
             };


### PR DESCRIPTION
API to get and set antenna's target.

This required quite a number of methods to be added to the API. The target can be an active vessel, a ground station, a celestial body, any vessel or there can be no target. At first I thought about providing few versions of the same method:

```
SetAntennaTargetToActiveVessel(Part part);
SetAntennaTargetToGroundStation(Part part, String groundStationName);
SetAntennaTargetToCelestialBody(Part part, CelestialBody cb);
...
```

but `GetAntennaTarget(Part part)` would still require the user to figure out what the required Guid (or object) represents. This is why I ended up providing simple `SetAntennaTarget(Part part, Guid id)` and methods to obtain the Guids for various types of objects.