### PR TITLE
MissionControl Update pack

### DIFF
--- a/GameData/RemoteTech/Default_Settings.cfg
+++ b/GameData/RemoteTech/Default_Settings.cfg
@@ -4,6 +4,7 @@ RemoteTechSettings
 	ConsumptionMultiplier = 1
 	RangeMultiplier = 1
 	ActiveVesselGuid = 35b89a0d664c43c6bec8d0840afc97b2
+	NoTargetGuid = 00000000-0000-0000-0000-000000000000
 	SpeedOfLight = 3E+08
 	MapFilter = Omni, Dish, Path
 	EnableSignalDelay = True
@@ -12,7 +13,11 @@ RemoteTechSettings
 	ThrottleTimeWarp = True
 	ThrottleZeroOnNoConnection = True
 	HideGroundStationsBehindBody = True
-  ControlAntennaWithoutConnection = False
+	ControlAntennaWithoutConnection = False
+	UpgradeableMissionControlAntennas = True
+	HideGroundStationsOnDistance = True
+	ShowMouseOverInfoGroundStations = True
+	DistanceToHideGroundStations = 3E+07
 	DishConnectionColor = 0.9960784,0.7019608,0.03137255,1
 	OmniConnectionColor = 0.5529412,0.5176471,0.4078431,1
 	ActiveConnectionColor = 0.6588235,1,0.01568628,1
@@ -32,7 +37,7 @@ RemoteTechSettings
 			{
 				ANTENNA
 				{
-					Omni = 7.5E+07
+					UpgradeableOmni = 4E+06;3.0E+07;7.5E+07 
 					Dish = 0
 					CosAngle = 1
 				}

--- a/src/RemoteTech/Modules/MissionControlAntenna.cs
+++ b/src/RemoteTech/Modules/MissionControlAntenna.cs
@@ -9,6 +9,19 @@ namespace RemoteTech.Modules
         [Persistent] public float Dish = 0.0f;
         [Persistent] public double CosAngle = 1.0;
 
+        /// <summary>
+        /// Semicolon seperated list with omni ranges for each tech lvl of the tracking station
+        /// </summary>
+        [Persistent] public string UpgradeableOmni = String.Empty;
+        /// <summary>
+        /// Semicolon seperated list with dish ranges for each tech lvl of the tracking station
+        /// </summary>
+        [Persistent] public string UpgradeableDish = String.Empty;
+        /// <summary>
+        /// Semicolon seperated list with CosAngle ranges for each tech lvl of the tracking station
+        /// </summary>
+        [Persistent] public string UpgradeableCosAngle = String.Empty;
+
         public ISatellite Parent { get; set; }
 
         float IAntenna.Omni { get { return Omni; } }
@@ -22,6 +35,62 @@ namespace RemoteTech.Modules
         Guid IAntenna.Target { get { return new Guid(RTSettings.Instance.ActiveVesselGuid); } set { return; } }
         float IAntenna.Dish { get { return Dish; } }
         double IAntenna.CosAngle { get { return CosAngle; } }
+        
+        public void reloadUpgradeableAntennas(int techlvl = 0)
+        {
+            if (this.UpgradeableCosAngle != String.Empty && this.UpgradeableDish != String.Empty && this.UpgradeableOmni != String.Empty)
+                return;
+
+            int missionControlTechLevel = techlvl;
+            if(missionControlTechLevel == 0)
+            {
+                missionControlTechLevel = (int)((2 * ScenarioUpgradeableFacilities.GetFacilityLevel(SpaceCenterFacility.TrackingStation)) + 1);
+            }
+
+            // when the option is disabled, use always the thrid tech lvl
+            if (!RTSettings.Instance.UpgradeableMissionControlAntennas)
+            {
+                missionControlTechLevel = 3;
+            }
+
+            RTLog.Verbose("Reload upgradeable Antennas, TechLvl: {0}", RTLogLevel.LVL4, missionControlTechLevel);
+
+            if (this.UpgradeableOmni != String.Empty)
+            {
+                int missionControlTechLevelForOmni = missionControlTechLevel;
+                string[] omniRanges = this.UpgradeableOmni.Split(';');
+                if (missionControlTechLevelForOmni > omniRanges.Count())
+                {
+                    missionControlTechLevelForOmni = omniRanges.Count();
+                }
+
+                float.TryParse(omniRanges[missionControlTechLevelForOmni - 1], out this.Omni);
+            }
+
+            if (this.UpgradeableDish != String.Empty)
+            {
+                int missionControlTechLevelForDish = missionControlTechLevel;
+                string[] dishRanges = this.UpgradeableOmni.Split(';');
+                if (missionControlTechLevelForDish > dishRanges.Count())
+                {
+                    missionControlTechLevelForDish = dishRanges.Count();
+                }
+
+                float.TryParse(dishRanges[missionControlTechLevelForDish - 1], out this.Dish);
+            }
+
+            if (this.UpgradeableCosAngle != String.Empty)
+            {
+                int missionControlTechLevelForCAngle = missionControlTechLevel;
+                string[] cAngleRanges = this.UpgradeableOmni.Split(';');
+                if (missionControlTechLevelForCAngle > cAngleRanges.Count())
+                {
+                    missionControlTechLevelForCAngle = cAngleRanges.Count();
+                }
+
+                double.TryParse(cAngleRanges[missionControlTechLevelForCAngle - 1], out this.CosAngle);
+            }
+        }
 
         public void OnConnectionRefresh() { }
 

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -250,6 +250,14 @@ namespace RemoteTech
             mGuid = new Guid(Guid);
         }
 
+        public void reloadUpgradeableAntennas(int techlvl = 0)
+        {
+            foreach (var antenna in Antennas)
+            {
+                antenna.reloadUpgradeableAntennas(techlvl);
+            }
+        }
+
         void IPersistenceLoad.PersistenceLoad()
         {
             foreach (var antenna in Antennas)

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -6,6 +6,10 @@ namespace RemoteTech
 {
     public class RTSettings
     {
+        public static EventVoid OnSettingsChanged = new EventVoid("OnSettingsChanged");
+        public static EventVoid OnSettingsLoaded = new EventVoid("OnSettingsLoaded");
+        public static EventVoid OnSettingsSaved = new EventVoid("OnSettingsSaved");
+
         private static Settings mInstance;
         public static Settings Instance
         {
@@ -54,6 +58,10 @@ namespace RemoteTech
         [Persistent] public bool ThrottleZeroOnNoConnection = true;
         [Persistent] public bool HideGroundStationsBehindBody = true;
         [Persistent] public bool ControlAntennaWithoutConnection = false;
+        [Persistent] public bool UpgradeableMissionControlAntennas = true;
+        [Persistent] public bool HideGroundStationsOnDistance = true;
+        [Persistent] public bool ShowMouseOverInfoGroundStations = true;
+        [Persistent] public float DistanceToHideGroundStations = 3e7f;
         [Persistent] public Color DishConnectionColor = XKCDColors.Amber;
         [Persistent] public Color OmniConnectionColor = XKCDColors.BrownGrey;
         [Persistent] public Color ActiveConnectionColor = XKCDColors.ElectricLime;
@@ -114,6 +122,8 @@ namespace RemoteTech
                     ConfigNode save = new ConfigNode();
                     save.AddNode(details);
                     save.Save(Settings.File);
+
+                    RTSettings.OnSettingsSaved.Fire();
                 }
             }
             catch (Exception e) { RTLog.Notify("An error occurred while attempting to save: " + e.Message); }
@@ -209,7 +219,7 @@ namespace RemoteTech
             {
                 settings.Save();
             }
-
+            RTSettings.OnSettingsLoaded.Fire();
 
             return settings;
         }

--- a/src/RemoteTech/RTSpaceCentre.cs
+++ b/src/RemoteTech/RTSpaceCentre.cs
@@ -35,7 +35,7 @@ namespace RemoteTech
         {
             if (obj.name.Equals("TrackingStation"))
             {
-                RTLog.Notify("OnUpgradeableObjLevelChange {0} - lvl: {1}", RTLogLevel.LVL4, obj.name, lvl);
+                RTLog.Verbose("OnUpgradeableObjLevelChange {0} - lvl: {1}", RTLogLevel.LVL4, obj.name, lvl);
                 this.reloadUpgradableAntennas(lvl+1);
             }
         }

--- a/src/RemoteTech/UI/OptionWindow.cs
+++ b/src/RemoteTech/UI/OptionWindow.cs
@@ -111,6 +111,7 @@ namespace RemoteTech.UI
             if(GUILayout.Button("Close"))
             {
                 this.Hide();
+                RTSettings.OnSettingsChanged.Fire();
             }
             
             base.Window(uid);
@@ -389,6 +390,12 @@ namespace RemoteTech.UI
 
             this.mSettings.HideGroundStationsBehindBody = GUILayout.Toggle(this.mSettings.HideGroundStationsBehindBody, (this.mSettings.HideGroundStationsBehindBody) ? "Ground stations are hidden behind bodys" : "Ground stations always shown");
             GUILayout.Label("If true, ground stations occulued by the body they’re on will not be displayed. This prevents ground stations on the other side of the planet being visible through the planet itself.", this.mGuiHintText);
+
+            this.mSettings.HideGroundStationsOnDistance = GUILayout.Toggle(this.mSettings.HideGroundStationsOnDistance, (this.mSettings.HideGroundStationsOnDistance) ? "Ground stations are hidden on a defined distance" : "Ground stations always shown");
+            GUILayout.Label("If true, ground stations would be invisible on a defined distance to the mapview camera.", this.mGuiHintText);
+
+            this.mSettings.ShowMouseOverInfoGroundStations = GUILayout.Toggle(this.mSettings.ShowMouseOverInfoGroundStations, (this.mSettings.ShowMouseOverInfoGroundStations) ? "Mouseover of ground stations enabled" : "Mouseover of ground stations disabled");
+            GUILayout.Label("If enabled you can get some usefull informations of a ground station by moving the mouse over it on the map view / tracking station", this.mGuiHintText);
         }
 
         /// <summary>
@@ -402,6 +409,10 @@ namespace RemoteTech.UI
 
             this.mSettings.ThrottleZeroOnNoConnection = GUILayout.Toggle(this.mSettings.ThrottleZeroOnNoConnection, (this.mSettings.ThrottleZeroOnNoConnection) ? "Throttle to zero on no connection" : "Keeps the throttle on no connection");
             GUILayout.Label("If true, the flight computer cuts the thrust (not on boosters) if you have no connection to mission control.", this.mGuiHintText);
+
+            this.mSettings.UpgradeableMissionControlAntennas = GUILayout.Toggle(this.mSettings.UpgradeableMissionControlAntennas, (this.mSettings.UpgradeableMissionControlAntennas) ? "MissionControl antennas are upgradeable": "MissionControl antennas are not upgradeable");
+            GUILayout.Label("If this option is activated, the mission controll ground station would be upgradable with the tracking center.", this.mGuiHintText);
+            
         }
 
         /// <summary>


### PR DESCRIPTION
##### General
- The mission control dot on the map view will now be invisible on a defined distance to the camera. See `DistanceToHideGroundStations` on the settings file. This feature can be toggled by the value
`HideGroundStationsOnDistance` in the option window.
- I've added a mouse over info box for each mission control dot on the map view. This feature can be toggled by the value `ShowMouseOverInfoGroundStations` in the option window.

![clipboard01](https://cloud.githubusercontent.com/assets/7722222/10122415/70cb749e-6519-11e5-83d1-1bc6e961071c.jpg)


##### Modders
- Ground station antennas can now use the tech level of the tracking station. I've added three new values to the antenna node for a station. Use `UpgradeableOmni`, `UpgradeableDish` and `UpgradeableCosAngle` with a semicolon seperated list of ranges. Example: 4E+06;3.0E+07;7.5E+07

closes #386

##### Contributors
- I've added three trigger events for the RTSettings. `OnSettingsChanged` will be fired when the option window is closed. `OnSettingsLoaded` will be fired when the settings is fully loaded, and `OnSettingsSaved` will be fired by saving the rtsettings file.