### PR TITLE
Better local control and connected status

### DIFF
--- a/src/RemoteTech/UI/TimeWarpDecorator.cs
+++ b/src/RemoteTech/UI/TimeWarpDecorator.cs
@@ -15,7 +15,6 @@ namespace RemoteTech.UI
         /// Delay-Text style
         /// </summary>
         private GUIStyle mTextStyle;
-
         /// <summary>
         /// Green Flightcomputer button
         /// </summary>
@@ -77,12 +76,12 @@ namespace RemoteTech.UI
                 {
                     return mFlightButtonRed;
                 }
-                else if (vs.HasLocalControl)
-                {
-                    return mFlightButtonYellow;
-                }
+
                 else if (vs.Connections.Any())
                 {
+                    if (vs.HasLocalControl)
+                        return mFlightButtonYellow;
+
                     return mFlightButtonGreen;
                 }
                 return mFlightButtonRed;
@@ -152,6 +151,12 @@ namespace RemoteTech.UI
             // draw the image
             GUI.DrawTexture(pos, mTexBackground);
             // draw the delay-text
+            mTextStyle.normal.textColor = new Color(0.56078f, 0.10196f, 0.07450f);
+            if (this.mVessel != null && this.mVessel.Connections.Any())
+            {
+                mTextStyle.normal.textColor = XKCDColors.GreenApple;
+            }
+
             GUI.Label(delaytextPosition, DisplayText, mTextStyle);
 
             // draw the flightcomputer button to the right relativ to the delaytext position


### PR DESCRIPTION
The label `Local control` and the yellow flight computer button will now change the color when the vessel has no connection.

Connected | Disconnected
------------ | -------------
![lc_connected](https://cloud.githubusercontent.com/assets/7722222/10416236/4adf4a30-700e-11e5-8f08-6df57bac041d.jpg) | ![lc_disconnected](https://cloud.githubusercontent.com/assets/7722222/10416237/4e58eac2-700e-11e5-8ef6-93c139d2bcb7.jpg)

closes #267