### PR TITLE
Provide a way of calling the original BaseEvent

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -4,6 +4,8 @@ using RemoteTech.SimpleTypes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using WrappedEvent = RemoteTech.FlightComputer.UIPartActionMenuPatcher.WrappedEvent;
+
 
 namespace RemoteTech.API
 {
@@ -250,6 +252,20 @@ namespace RemoteTech.API
 			}
 
             return RTSettings.Instance.RemoveGroundStation(stationid);
+        }
+
+        // this method provides a workaround for issue #437, it may be possible to remove it in the future
+        public static void InvokeOriginalEvent(BaseEvent e)
+        {
+            if (e is WrappedEvent)
+            {
+                WrappedEvent wrappedEvent = e as WrappedEvent;
+                wrappedEvent.InvokeOriginalEvent();
+            }
+            else
+            {
+                e.Invoke();
+            }
         }
     }
 }

--- a/src/RemoteTech/FlightComputer/UIPartActionMenuPatcher.cs
+++ b/src/RemoteTech/FlightComputer/UIPartActionMenuPatcher.cs
@@ -64,6 +64,22 @@ namespace RemoteTech.FlightComputer
             }
         }
 
+        public class WrappedEvent : BaseEvent
+        {
+            private BaseEvent originalEvent;
+
+            public WrappedEvent(BaseEvent originalEvent, BaseEventList baseParentList, string name, BaseEventDelegate baseActionDelegate)
+                : base(baseParentList, name, baseActionDelegate)
+            {
+                this.originalEvent = originalEvent;
+            }
+
+            public void InvokeOriginalEvent()
+            {
+                originalEvent.Invoke();
+            }
+        }
+
         private class Wrapper
         {
             private Action<BaseEvent, bool> mPassthrough;
@@ -82,11 +98,12 @@ namespace RemoteTech.FlightComputer
                 ConfigNode cn = new ConfigNode();
                 original.OnSave(cn);
                 Wrapper wrapper = new Wrapper(original, passthrough, ignore_delay);
-                BaseEvent new_event = new BaseEvent(original.listParent, original.name, wrapper.Invoke);
+                BaseEvent new_event = new WrappedEvent(original, original.listParent, original.name, wrapper.Invoke);
                 new_event.OnLoad(cn);
 
                 return new_event;
             }
+
 
             [KSPEvent(category = "skip_control")]
             public void Invoke()


### PR DESCRIPTION
Fixes #437 

Provides a workaround so that the original BaseEvent can be called. I hope that in the future #388 will be resolved in some other way and this will not be needed anymore. For now there seems to be no alternative.

