### PR TITLE
Fc execution changes

### DIFF
--- a/GameData/RemoteTech/Default_Settings.cfg
+++ b/GameData/RemoteTech/Default_Settings.cfg
@@ -18,6 +18,8 @@ RemoteTechSettings
 	HideGroundStationsOnDistance = True
 	ShowMouseOverInfoGroundStations = True
 	AutoInsertKaCAlerts = True
+	FCLeadTime = 180;
+    FCOffAfterExecute = false;
 	DistanceToHideGroundStations = 3E+07
 	DishConnectionColor = 0.9960784,0.7019608,0.03137255,1
 	OmniConnectionColor = 0.5529412,0.5176471,0.4078431,1

--- a/GameData/RemoteTech/Default_Settings.cfg
+++ b/GameData/RemoteTech/Default_Settings.cfg
@@ -19,7 +19,7 @@ RemoteTechSettings
 	ShowMouseOverInfoGroundStations = True
 	AutoInsertKaCAlerts = True
 	FCLeadTime = 180;
-    FCOffAfterExecute = false;
+	FCOffAfterExecute = false;
 	DistanceToHideGroundStations = 3E+07
 	DishConnectionColor = 0.9960784,0.7019608,0.03137255,1
 	OmniConnectionColor = 0.5529412,0.5176471,0.4078431,1

--- a/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
@@ -82,7 +82,7 @@ namespace RemoteTech.FlightComputer.Commands
         /// <summary>
         /// Executes this command and invokes the <see cref="ReflectionExecuteMethod"/>
         /// on the <see cref="ReflectionType"/>. When this command is aborted the
-        /// fallback commnd is "KillRot".
+        /// fallback commnd is "Off".
         /// </summary>
         /// <param name="computer">Current flightcomputer</param>
         /// <param name="ctrlState">Current FlightCtrlState</param>
@@ -97,8 +97,8 @@ namespace RemoteTech.FlightComputer.Commands
                 finished = (bool)this.callReflectionMember(this.ReflectionExecuteMethod);
                 if (this.AbortCommand)
                 {
-                    // enqueue killRot after aborting this command
-                    computer.Enqueue(AttitudeCommand.KillRot(), true, true, true);
+                    // disable FC after aborting this command
+                    computer.Enqueue(AttitudeCommand.Off(), true, true, true);
                     finished = true;
                 }
             }

--- a/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
@@ -97,9 +97,16 @@ namespace RemoteTech.FlightComputer.Commands
                 finished = (bool)this.callReflectionMember(this.ReflectionExecuteMethod);
                 if (this.AbortCommand)
                 {
-                    // disable FC after aborting this command
-                    computer.Enqueue(AttitudeCommand.Off(), true, true, true);
-                    finished = true;
+                    if (RTSettings.Instance.FCOffAfterExecute)
+                    {
+                        computer.Enqueue(AttitudeCommand.Off(), true, true, true);
+                        finished = true;
+                    }
+                    if (!RTSettings.Instance.FCOffAfterExecute)
+                    {
+                        computer.Enqueue(AttitudeCommand.KillRot(), true, true, true);
+                        finished = true;
+                    }
                 }
             }
 

--- a/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ExternalAPICommand.cs
@@ -82,7 +82,7 @@ namespace RemoteTech.FlightComputer.Commands
         /// <summary>
         /// Executes this command and invokes the <see cref="ReflectionExecuteMethod"/>
         /// on the <see cref="ReflectionType"/>. When this command is aborted the
-        /// fallback commnd is "Off".
+        /// fallback commnd is "KillRot".
         /// </summary>
         /// <param name="computer">Current flightcomputer</param>
         /// <param name="ctrlState">Current FlightCtrlState</param>

--- a/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
@@ -84,8 +84,16 @@ namespace RemoteTech.FlightComputer.Commands
             {
                 Node.RemoveSelf();
             }
-            // switch FC to Off after a maneuver is completed (and/or Aborted?) instead of KillRot
-            computer.Enqueue(AttitudeCommand.Off(), true, true, true);
+
+            // Flight Computer mode after execution based on settings
+            if (RTSettings.Instance.FCOffAfterExecute)
+            {
+                computer.Enqueue(AttitudeCommand.Off(), true, true, true);
+            }
+            if (!RTSettings.Instance.FCOffAfterExecute)
+            {
+                computer.Enqueue(AttitudeCommand.KillRot(), true, true, true);
+            }
         }
 
         /// <summary>
@@ -251,7 +259,7 @@ namespace RemoteTech.FlightComputer.Commands
         public override void CommandEnqueued(FlightComputer computer)
         {
 			string KaCAddonLabel = String.Empty;
-			double timetoexec = (this.TimeStamp + this.ExtraDelay) - RTSettings.Instance.LeadTime;
+			double timetoexec = (this.TimeStamp + this.ExtraDelay) - RTSettings.Instance.FCLeadTime;
 
             if (timetoexec - RTUtil.GameTime >= 0 && RTSettings.Instance.AutoInsertKaCAlerts == true)
             {

--- a/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
@@ -258,8 +258,8 @@ namespace RemoteTech.FlightComputer.Commands
         /// <param name="computer">Current flightcomputer</param>
         public override void CommandEnqueued(FlightComputer computer)
         {
-			string KaCAddonLabel = String.Empty;
-			double timetoexec = (this.TimeStamp + this.ExtraDelay) - RTSettings.Instance.FCLeadTime;
+            string KaCAddonLabel = String.Empty;
+            double timetoexec = (this.TimeStamp + this.ExtraDelay) - RTSettings.Instance.FCLeadTime;
 
             if (timetoexec - RTUtil.GameTime >= 0 && RTSettings.Instance.AutoInsertKaCAlerts == true)
             {

--- a/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
+++ b/src/RemoteTech/FlightComputer/Commands/ManeuverCommand.cs
@@ -84,8 +84,8 @@ namespace RemoteTech.FlightComputer.Commands
             {
                 Node.RemoveSelf();
             }
-            // enqueue kill rot
-            computer.Enqueue(AttitudeCommand.KillRot(), true, true, true);
+            // switch FC to Off after a maneuver is completed (and/or Aborted?) instead of KillRot
+            computer.Enqueue(AttitudeCommand.Off(), true, true, true);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace RemoteTech.FlightComputer.Commands
         public override bool Execute(FlightComputer computer, FlightCtrlState ctrlState)
         {
             // Halt the command if we reached our target or were command to abort by the previous tick
-            if (this.RemainingDelta <= 0.01 || this.abortOnNextExecute)
+            if (this.RemainingDelta <= 0.1 || this.abortOnNextExecute)
             {
                 this.AbortManeuver(computer);
                 return true;
@@ -250,8 +250,8 @@ namespace RemoteTech.FlightComputer.Commands
         /// <param name="computer">Current flightcomputer</param>
         public override void CommandEnqueued(FlightComputer computer)
         {
-            string KaCAddonLabel = String.Empty;
-            double timetoexec = (this.TimeStamp + this.ExtraDelay) - 180;
+			string KaCAddonLabel = String.Empty;
+			double timetoexec = (this.TimeStamp + this.ExtraDelay) - RTSettings.Instance.LeadTime;
 
             if (timetoexec - RTUtil.GameTime >= 0 && RTSettings.Instance.AutoInsertKaCAlerts == true)
             {

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -63,7 +63,8 @@ namespace RemoteTech
         [Persistent] public bool HideGroundStationsOnDistance = true;
         [Persistent] public bool ShowMouseOverInfoGroundStations = true;
         [Persistent] public bool AutoInsertKaCAlerts = true;
-        [Persistent] public float DistanceToHideGroundStations = 3e7f;
+		[Persistent] public int LeadTime = 180;
+		[Persistent] public float DistanceToHideGroundStations = 3e7f;
         [Persistent] public Color DishConnectionColor = XKCDColors.Amber;
         [Persistent] public Color OmniConnectionColor = XKCDColors.BrownGrey;
         [Persistent] public Color ActiveConnectionColor = XKCDColors.ElectricLime;

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -63,7 +63,8 @@ namespace RemoteTech
         [Persistent] public bool HideGroundStationsOnDistance = true;
         [Persistent] public bool ShowMouseOverInfoGroundStations = true;
         [Persistent] public bool AutoInsertKaCAlerts = true;
-		[Persistent] public int LeadTime = 180;
+        [Persistent] public int FCLeadTime = 180;
+        [Persistent] public bool FCOffAfterExecute = false;
 		[Persistent] public float DistanceToHideGroundStations = 3e7f;
         [Persistent] public Color DishConnectionColor = XKCDColors.Amber;
         [Persistent] public Color OmniConnectionColor = XKCDColors.BrownGrey;

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -65,7 +65,7 @@ namespace RemoteTech
         [Persistent] public bool AutoInsertKaCAlerts = true;
         [Persistent] public int FCLeadTime = 180;
         [Persistent] public bool FCOffAfterExecute = false;
-		[Persistent] public float DistanceToHideGroundStations = 3e7f;
+        [Persistent] public float DistanceToHideGroundStations = 3e7f;
         [Persistent] public Color DishConnectionColor = XKCDColors.Amber;
         [Persistent] public Color OmniConnectionColor = XKCDColors.BrownGrey;
         [Persistent] public Color ActiveConnectionColor = XKCDColors.ElectricLime;


### PR DESCRIPTION
Some minor adjustments to the FC functionality.  Started off by changing FC fallback after execution/abort to Off but then changed replaced that to using a field so it's user configurable.  Also made the lead time on attitude adjustment variable instead of hard coded for 3 minutes. The defaults are mimicking current functionality so nobody loses.  I didn't update the UI to control these settings.