### PR TITLE
Dish mass adjustments for gameplay and realism reasons

### DIFF
--- a/GameData/RemoteTech/Parts/GigaDish1/part.cfg
+++ b/GameData/RemoteTech/Parts/GigaDish1/part.cfg
@@ -20,7 +20,7 @@ description = A massive medium-interplanetary class dish. Wherever you are in th
 
 attachRules = 1,1,1,0,0
 
-mass = 0.5
+mass = 0.24
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.2

--- a/GameData/RemoteTech/Parts/GigaDish2/part.cfg
+++ b/GameData/RemoteTech/Parts/GigaDish2/part.cfg
@@ -23,7 +23,7 @@ description = A powerful high-gain fixed dish. It can reach almost anything in t
 
 attachRules = 1,1,1,0,0
 
-mass = 1
+mass = 0.3
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.2

--- a/GameData/RemoteTech/Parts/LongDish2/part.cfg
+++ b/GameData/RemoteTech/Parts/LongDish2/part.cfg
@@ -23,7 +23,7 @@ description = Replacing the LL-5, this dish will carry your signal beyond Duna l
 
 attachRules = 1,1,0,0,1
 
-mass = 1.0
+mass = 0.2
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.2

--- a/GameData/RemoteTech/Parts/ShortDish2/part.cfg
+++ b/GameData/RemoteTech/Parts/ShortDish2/part.cfg
@@ -23,7 +23,7 @@ description = Locals complained about their missing garbage lids, so our enginee
 
 attachRules = 1,1,0,0,1
 
-mass = 0.5
+mass = 0.05
 dragModelType = default
 maximum_drag = 0.2
 minimum_drag = 0.2


### PR DESCRIPTION
Currently the RT dishes are extremely heavy, not only in comparison to the stock KSP parts, but even in comparison to real life.

With the old masses, there was little incentive to use RT parts, especially unmanned probes with RT dishes for more than kerbin orbital missions. The RT dishes would often be at least as heavy as the whole probe including propulsion.

The proposed values are take from the SETIrebalance mod, where they have been very well recieved for over a year.

Best regards,
Y3mo/Yemo