### PR TITLE
DP-10 attachment and physics significance

### DIFF
--- a/GameData/RemoteTech/Parts/ShortAntenna1/part.cfg
+++ b/GameData/RemoteTech/Parts/ShortAntenna1/part.cfg
@@ -10,7 +10,7 @@ specPower = 0.1
 rimFalloff = 3
 alphaCutoff = 0.5
 
-node_attach = 0.46, 0.0, 0.0, 1.0, 0.0, 0.0
+node_attach = 0.21, 0.0, 0.0, 1.0, 0.0, 0.0
 
 entryCost = 200
 cost = 60
@@ -29,5 +29,6 @@ minimum_drag = 0.2
 angularDrag = 2
 crashTolerance = 8
 maxTemp = 1200
+PhysicsSignificance = 1
 
 }


### PR DESCRIPTION
Corrects the attachment distance (gap) of the DP-10.

Also removes physics significance, as is expected of parts with a mass of 5kg (eg z100 battery, thermo, baro). So that the part adds it's mass to the part it is attached to and thus does not skew the center of mass (a common issue for very lightweight DP-10 equipped probes).

Taken from SETI.

Best regards,
Y3mo/Yemo