### PR TITLE
RemoteTech Compatibility Patch For Ven's Stock Revamp

### DIFF
--- a/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
+++ b/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
@@ -1,0 +1,102 @@
+// RemoteTech Compatibility Patch For Ven's Stock Revamp
+// Author: Sandriell (http://forum.kerbalspaceprogram.com/index.php?/profile/165509-sandriell/)
+
+// Communotron 32 (Renamed: Communotron DTS-M2)
+@PART[LongDeployableAntenna]:NEEDS[RemoteTech]
+{
+    @title = Communotron DTS-M2
+    @description = The bigger brother of the Communotron DTS-M1, the DTS-M2 is a deployable, power-hungry solution to most of your medium-range communications needs. Held together with extra-reflective ductape!
+    @cost = 900
+    !MODULE[ModuleDataTransmitter] {}
+
+    %MODULE[ModuleRTAntenna] {
+        %Mode0DishRange =  0
+        %Mode1DishRange = 1000000000
+        %DishAngle = 20.0
+        %EnergyCost = 0.95
+        %MaxQ = 3000
+
+        %DeployFxModules = 0
+        %ProgressFxModules = 1
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+// Comms DTS-M5 (Renamed: Communotron DTS-M5)
+@PART[SmallFixedAntenna]:NEEDS[RemoteTech]
+{
+    @title = Communotron DTS-M5
+    @description = The Communotron DTS-M5 is a fixed, medium-range dish with a very narrow cone angle and high electric cost. The fancy, totally not made of from one of Jeb's mother's good bed sheets, covering will allow higher temperature tolerances.
+    @cost = 1000
+    @maxTemp = 2200
+    @mass = 0.55
+    !MODULE[ModuleDataTransmitter] {}
+
+    %MODULE[ModuleRTAntenna] {
+        %Mode0DishRange =  0
+        %Mode1DishRange = 5000000000
+        %DishAngle = .05
+        %EnergyCost = 1.0
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+// Comms DTS-M7 (Renamed: Communotron DTS-M7)
+@PART[mediumFixedAntenna]:NEEDS[RemoteTech]
+{
+    @title = Communotron DTS-M7
+    @description = The Communotron DTS-M7 is a medium-range dish that offers a decent cone-angle at the cost of extra weight and electric cost.
+    @mass = 1.10
+    !MODULE[ModuleDataTransmitter] {}
+
+    %MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 45000000000
+		%EnergyCost = 1.10
+		%DishAngle = .10
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}
+
+// Communotron 88-X
+@PART[largeFixedAntenna]:NEEDS[RemoteTech]
+{
+    @description = The Communotron 88-X is the chubby hotrod of antennas, fast, long-range communications can be yours in a bulky 3 meter package.
+    @mass = 2.0
+    @cost = 11000
+    @crashTolerance = 10
+    @maxTemp = 2800
+    !MODULE[ModuleDataTransmitter] {}
+
+    %MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 500000000000
+		%EnergyCost = 3.40
+		%DishAngle = 0.0065
+
+        %TRANSMITTER
+        {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+}


### PR DESCRIPTION
RemoteTech Compatibility Patch For Ven's Stock Revamp

Added everything needed for them to work with RemoteTech but also tweaked several of the stats in an attempt to balance them against existing Stock/RemoteTech dishes.