### PR TITLE
Config for Ven's Stock Part Revamp Antennas

### DIFF
--- a/GameData/RemoteTech/RemoteTech_VenStockRevamp_Antennas.cfg
+++ b/GameData/RemoteTech/RemoteTech_VenStockRevamp_Antennas.cfg
@@ -1,0 +1,109 @@
+@PART[largeFixedAntenna]:FOR[RemoteTech]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}	
+	
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 400000000000
+		%EnergyCost = 2.8
+		%MaxQ = 6000
+		%DishAngle = 0.006
+		
+		%DeployFxModules = 0
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+@PART[mediumFixedAntenna]:FOR[RemoteTech]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}	
+	
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 60000000000
+		%EnergyCost = 0.93
+		%MaxQ = 6000
+		%DishAngle = 0.04
+		
+		%DeployFxModules = 0
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+@PART[smallFixedAntenna]:FOR[RemoteTech]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}	
+	
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 90000000
+		%EnergyCost = 0.82
+		%MaxQ = 6000
+		%DishAngle = 25.0
+		
+		%DeployFxModules = 0
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+@PART[longDeployableAntenna]:FOR[RemoteTech]
+{
+	!MODULE[ModuleDataTransmitter] {}
+	
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] {
+		%Mode0OmniRange = 0
+		%Mode1OmniRange = 7500000
+		%MaxQ = 6000
+		%EnergyCost = .95
+		%DishAngle = 30
+		
+		%DeployFxModules = 0
+		%ProgressFxModules = 1
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}


### PR DESCRIPTION
This adds antenna configs for the new antennas added by Ven's Stock Part Revamp.  I think they are inline with their size vs the RemoteTech ones.
