### PR TITLE
Fixed the GUIClips spam when reading the debug-purpose list of vessels and ground stations at the KSC scene

### DIFF
--- a/src/RemoteTech/UI/DebugWindow.cs
+++ b/src/RemoteTech/UI/DebugWindow.cs
@@ -468,14 +468,24 @@ namespace RemoteTech.UI
 
             // draw the Ground stations
             #region Ground stations
-            foreach (var stations in RTCore.Instance.Network.GroundStations)
+            if (HighLogic.LoadedScene == GameScenes.SPACECENTER)
             {
                 GUILayout.BeginHorizontal();
-                {
-                    GUILayout.Label(stations.Value.Name, GUILayout.ExpandWidth(true));
-                    GUILayout.TextField(stations.Key.ToString(), GUILayout.Width(270));
-                }
+                GUILayout.Label("Ground stations are only available in the flight or tracking station.", GUILayout.ExpandWidth(true));
                 GUILayout.EndHorizontal();
+            }
+            else
+            {
+                foreach (var stations in RTCore.Instance.Network.GroundStations)
+                {
+                    GUILayout.BeginHorizontal();
+                    {
+                        GUILayout.Label(stations.Value.Name, GUILayout.ExpandWidth(true));
+                        GUILayout.TextField(stations.Key.ToString(), GUILayout.Width(270));
+                    }
+                    GUILayout.EndHorizontal();
+                }
+                
             }
             #endregion
         }


### PR DESCRIPTION
Stock KSP 1.2.1586

Reproduction steps:
1) Get into KSC scene of a sandbox save
2) Alt + F12 to bring up the RT debug window (other than KSP cmd window)
3) Click the third button of "GUID-Reader"
4) Spam messages on the GUIClips error:
/-------------------------------------------------------------
GUI Error: You are pushing more GUIClips than you are popping. Make sure they are balanced)

(Filename: Line: 422)

NullReferenceException: Object reference not set to an instance of an object
at RemoteTech.UI.DebugWindow.drawGuidReader () [0x00000] in :0 
at RemoteTech.UI.DebugWindow.Window (Int32 uid) [0x00000] in :0 
at RemoteTech.UI.AbstractWindow.WindowPre (Int32 uid) [0x00000] in :0 
at UnityEngine.GUILayout+LayoutedWindow.DoWindow (Int32 windowID) [0x00000] in :0 
at UnityEngine.GUI.CallWindowDelegate (UnityEngine.WindowFunction func, Int32 id, UnityEngine.GUISkin _skin, Int32 forceRect, Single width, Single height, UnityEngine.GUIStyle style) [0x00000] in :0

(Filename: Line: -1)

GUI Error: You are pushing more GUIClips than you are popping. Make sure they are balanced)
/-------------------------------------------------------------