### PR TITLE
RT config for new stock antennas

### DIFF
--- a/GameData/RemoteTech/RemoteTech_Antennas.cfg
+++ b/GameData/RemoteTech/RemoteTech_Antennas.cfg
@@ -3,7 +3,7 @@
 
 @PART[RTShortAntenna1]:FOR[RemoteTech]
 {
-	%TechRequired = flightControl
+	%TechRequired = start
 	%MODULE[ModuleRTAntenna] {
 		%IsRTActive = true
 		%Mode0OmniRange = 0

--- a/GameData/RemoteTech/RemoteTech_Squad_Antennas.cfg
+++ b/GameData/RemoteTech/RemoteTech_Squad_Antennas.cfg
@@ -1,6 +1,11 @@
 // Support for stock antennas
 // Original config by Cilph
 
+@PART[*]:HAS[@MODULE[ModuleDataTransmitter]]:FOR[RemoteTech]
+{
+	!MODULE[ModuleDataTransmitter]{}
+}
+
 @PART[launchClamp1]:FOR[RemoteTech]
 {
 	%MODULE[ModuleRTAntennaPassive] {
@@ -10,8 +15,6 @@
 
 @PART[longAntenna]:FOR[RemoteTech]
 {
-	!MODULE[ModuleDataTransmitter] {}
-	
 	@MODULE[ModuleAnimateGeneric]
 	{
 		%allowManualControl = false
@@ -37,8 +40,6 @@
 
 @PART[mediumDishAntenna]:FOR[RemoteTech]
 {
-	!MODULE[ModuleDataTransmitter] {}
-	
 	@MODULE[ModuleAnimateGeneric]
 	{
 		%allowManualControl = false
@@ -66,8 +67,6 @@
 
 @PART[commDish]:FOR[RemoteTech]
 {
-	!MODULE[ModuleDataTransmitter] {}
-	
 	@MODULE[ModuleAnimateGeneric]
 	{
 		%allowManualControl = false
@@ -94,8 +93,6 @@
 
 @PART[HighGainAntenna]:FOR[RemoteTech]
 {
-	!MODULE[ModuleDataTransmitter] {}
-	
 	@MODULE[ModuleAnimateGeneric]
 	{
 		%allowManualControl = false
@@ -115,6 +112,106 @@
 			%PacketInterval = 0.15
 			%PacketSize = 3
 			%PacketResourceCost = 20.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[SurfAntenna]:FOR[RemoteTech]
+{
+	%MODULE[ModuleRTAntenna] {
+		%IsRTActive = true
+		%Mode0OmniRange = 0
+		%Mode1OmniRange = 1500000
+		%EnergyCost = 0.02
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+
+@PART[HighGainAntenna5]:FOR[RemoteTech]
+{
+	@MODULE[ModuleAnimateGeneric]
+	{
+		%allowManualControl = false
+	}
+	
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 20000000
+		%EnergyCost = 0.55
+		%MaxQ = 6000
+		%DishAngle = 90
+		
+		%DeployFxModules = 0
+		%ProgressFxModules = 1
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.15
+			%PacketSize = 3
+			%PacketResourceCost = 20.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[RelayAntenna100]:FOR[RemoteTech]
+{
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 100000000000
+		%EnergyCost = 1.1
+		%DishAngle = 0.025
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[RelayAntenna5]:FOR[RemoteTech]
+{
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 200000000
+		%EnergyCost = 1.15
+		%DishAngle = 12.5
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
+@PART[RelayAntenna50]:FOR[RemoteTech]
+{
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 10000000000
+		%EnergyCost = 1.1
+		%DishAngle = 0.25
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
 		}
 	}
 	


### PR DESCRIPTION
- MM patch for new antennas in KSP1.2 adds RT modules and adjusts weight to be more in line with RT antennas 
- includes MM patch to remove ALL occurences of ModuleDataTransmitter as it's now present in command pods too.
- moved DP-10 to start tech to replace the ModuleDataTransmitter removed from command pods.