### PR TITLE
Add RemoteTech config for the Communotron 88-88-V from Vens Stock Revamp

### DIFF
--- a/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
+++ b/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
@@ -104,21 +104,11 @@
 // Communotron 88-88-V
 @PART[commDishVSR]:FOR[RemoteTech]
 {
-    @MODULE[ModuleDeployableAntenna]
-    {
-        %name=ModuleAnimateGeneric
-        %allowManualControl = false
-        %actionAvailable = false
-        %eventAvailableFlight = false
-        %eventAvailableEditor = false
-        %eventAvailableEVA = false
-    }
-    
     %MODULE[ModuleRTAntenna] {
         %Mode0DishRange = 0
         %Mode1DishRange = 40000000000
         %EnergyCost = 0.93
-        %MaxQ = 6000
+        %MaxQ = 2000
         %DishAngle = 0.06
         
         %DeployFxModules = 0
@@ -129,6 +119,4 @@
             %PacketResourceCost = 15.0
         }
     }
-    
-    %MODULE[ModuleSPUPassive] {}
 }

--- a/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
+++ b/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
@@ -102,7 +102,7 @@
 }
 
 // Communotron 88-88-V
-@PART[commDish]:FOR[RemoteTech]
+@PART[commDishVSR]:FOR[RemoteTech]
 {
     @MODULE[ModuleDeployableAntenna]
     {

--- a/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
+++ b/GameData/RemoteTech/RemoteTech_VensStockRevamp.cfg
@@ -100,3 +100,35 @@
         }
     }
 }
+
+// Communotron 88-88-V
+@PART[commDish]:FOR[RemoteTech]
+{
+    @MODULE[ModuleDeployableAntenna]
+    {
+        %name=ModuleAnimateGeneric
+        %allowManualControl = false
+        %actionAvailable = false
+        %eventAvailableFlight = false
+        %eventAvailableEditor = false
+        %eventAvailableEVA = false
+    }
+    
+    %MODULE[ModuleRTAntenna] {
+        %Mode0DishRange = 0
+        %Mode1DishRange = 40000000000
+        %EnergyCost = 0.93
+        %MaxQ = 6000
+        %DishAngle = 0.06
+        
+        %DeployFxModules = 0
+        
+        %TRANSMITTER {
+            %PacketInterval = 0.3
+            %PacketSize = 2
+            %PacketResourceCost = 15.0
+        }
+    }
+    
+    %MODULE[ModuleSPUPassive] {}
+}


### PR DESCRIPTION
I added this change to fix the 88-88-V from vens stock revamp not having RemoteTech configs. Let me know if you would prefer me to create an issue or provide more detail in any way. This change only copies the config for the 88-88 to work for the 88-88-V. I can update with logs/modlist/persistent/screenshots if necessary.

O.S: Windows 10 64-bit
KSP: 1.3 64-bit
Problem: New antenna 88-88-V in Vens Stock Revamp does not have RemoteTech configs.

Reproduction steps:
    Install RemoteTech and Vens Stock Revamp. Hovering on the 88-88-V in VAB shows no RemoteTech info. Build a ship with the 88-88-V. Launch and fly. No RemoteTech connection.
