### PR TITLE
Add cheat option to ignore line-of-sight requirements

### DIFF
--- a/GameData/RemoteTech/Default_Settings.cfg
+++ b/GameData/RemoteTech/Default_Settings.cfg
@@ -31,6 +31,7 @@ RemoteTechSettings
 	RemoteStationColorDot = 0.996078014,0,0,1
 	DirectConnectionColor = 0,0.749,0.952,1
 	SignalRelayEnabled = False
+	IgnoreLineOfSight = False
 	GroundStations
 	{
 		STATION

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -145,7 +145,7 @@ namespace RemoteTech
         public static NetworkLink<ISatellite> GetLink(ISatellite sat_a, ISatellite sat_b)
         {
             if (sat_a == null || sat_b == null || sat_a == sat_b) return null;
-            bool los = sat_a.HasLineOfSightWith(sat_b) || CheatOptions.InfinitePropellant || RTSettings.Instance.IgnoreLineOfSight;
+            bool los = sat_a.HasLineOfSightWith(sat_b) || RTSettings.Instance.IgnoreLineOfSight;
             if (!los) return null;
 
             switch (RTSettings.Instance.RangeModelType)

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -145,7 +145,7 @@ namespace RemoteTech
         public static NetworkLink<ISatellite> GetLink(ISatellite sat_a, ISatellite sat_b)
         {
             if (sat_a == null || sat_b == null || sat_a == sat_b) return null;
-            bool los = sat_a.HasLineOfSightWith(sat_b) || CheatOptions.InfinitePropellant;
+            bool los = sat_a.HasLineOfSightWith(sat_b) || CheatOptions.InfinitePropellant || RTSettings.Instance.IgnoreLineOfSight;
             if (!los) return null;
 
             switch (RTSettings.Instance.RangeModelType)

--- a/src/RemoteTech/RTSettings.cs
+++ b/src/RemoteTech/RTSettings.cs
@@ -71,6 +71,7 @@ namespace RemoteTech
         [Persistent] public Color RemoteStationColorDot;
         [Persistent] public Color DirectConnectionColor = new Color(0, 0.749f, 0.952f, 1); //TODO: remove two new values after some significant time - 7 Nov 2017
         [Persistent] public bool SignalRelayEnabled = false;
+        [Persistent] public bool IgnoreLineOfSight;
         [Persistent(collectionIndex = "STATION")] public List<MissionControlSatellite> GroundStations;
         [Persistent(collectionIndex = "PRESETS")] public List<string> PreSets;
 

--- a/src/RemoteTech/UI/DebugWindow.cs
+++ b/src/RemoteTech/UI/DebugWindow.cs
@@ -198,9 +198,9 @@ namespace RemoteTech.UI
             GUILayout.BeginHorizontal();
             {
                 GUILayout.Label("Signal Through Bodies: ", GUILayout.Width(firstColWidth));
-                int cheatEVAFuel = (CheatOptions.InfinitePropellant) ? 1 : 0;
-                RTUtil.FakeStateButton(new GUIContent("On"), () => { CheatOptions.InfinitePropellant = true; }, cheatEVAFuel, 1);
-                RTUtil.FakeStateButton(new GUIContent("Off"), () => { CheatOptions.InfinitePropellant = false; }, cheatEVAFuel, 0);
+                int cheatLineOfSight = (RTSettings.Instance.IgnoreLineOfSight) ? 1 : 0;
+                RTUtil.FakeStateButton(new GUIContent("On"), () => { RTSettings.Instance.IgnoreLineOfSight = true; }, cheatLineOfSight, 1);
+                RTUtil.FakeStateButton(new GUIContent("Off"), () => { RTSettings.Instance.IgnoreLineOfSight = false; }, cheatLineOfSight, 0);
             }
             GUILayout.EndHorizontal();
 

--- a/src/RemoteTech/UI/OptionWindow.cs
+++ b/src/RemoteTech/UI/OptionWindow.cs
@@ -474,6 +474,10 @@ namespace RemoteTech.UI
             GUILayout.Space(10);
             this.mSettings.ControlAntennaWithoutConnection = GUILayout.Toggle(this.mSettings.ControlAntennaWithoutConnection, (this.mSettings.ControlAntennaWithoutConnection) ? "No Connection needed to control antennas" : "Connection is needed to control antennas");
             GUILayout.Label("ON: antennas can be activated, deactivated and targeted without a connection.\nOFF: No control without a working connection.", this.mGuiHintText);
+
+            GUILayout.Space(10);
+            this.mSettings.IgnoreLineOfSight = GUILayout.Toggle(this.mSettings.IgnoreLineOfSight, (this.mSettings.IgnoreLineOfSight) ? "Planets and moons will not block a signal" : "Planets and moons will block a signal");
+            GUILayout.Label("ON: Antennas and dishes will not need line-of-sight to maintain a connection, as long as they have adequate range and power.\nOFF: Antennas and dishes need line-of-sight to maintain a connection.", this.mGuiHintText);
         }
 
         /// <summary>


### PR DESCRIPTION
Without having to go full infinite-propellent which messes with a lot more game mechanics.

~~Ideally I'd also stop having InfinitePropellant also override line-of-sight but I don't want to confuse anyone who is used to using it.~~ YOLO

cc @NathanKell 
