### PR TITLE
API methods primarily to support Kerbalism but can be used by others

### DIFF
--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -100,11 +100,9 @@ namespace RemoteTech.API
             return connectedToKerbin;
         }
 
-        /// <summary>
-        /// Determines if a vessel directly targets a ground station.
-        /// </summary>
+        /// <summary> Determines if a satellite directly targets a ground station.</summary>
         /// <param name="id">The vessels id.</param>
-        /// <returns>true if the vessel has an antenna with a ground station as its first link, false otherwise.</returns>
+        /// <returns>true if the satellite has an antenna with a ground station as its first link, false otherwise.</returns>
         public static bool HasGroundStationTarget(Guid id)
         {
             if (RTCore.Instance == null) return false;
@@ -114,6 +112,21 @@ namespace RemoteTech.API
             var targetsGroundStation = RTCore.Instance.Network[satellite].Any(r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Links.FirstOrDefault().Target.Guid));
             RTLog.Verbose("APIcall: {0} Directly targets a ground station {1}", RTLogLevel.API, id, targetsGroundStation);
             return targetsGroundStation;
+        }
+
+        /// <summary> Gets the name of the ground station directly targeted with the shortest link to the satellite.</summary>
+        /// <param name="id">The vessels id.</param>
+        /// <returns>name of the ground station if one is found, null otherwise.</returns>
+        public static string GetNameGroundStationTarget(Guid id)
+        {
+            if (RTCore.Instance == null) return null;
+            var satellite = RTCore.Instance.Satellites[id];
+            if (satellite == null) return null;
+
+            var namedGroundStation = RTCore.Instance.Network[satellite].Where
+                (r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Links.FirstOrDefault().Target.Guid)).Min().Goal.Name;
+            RTLog.Verbose("APIcall: {0} Directly targets with the shortest link the ground station {1}", RTLogLevel.API, id, namedGroundStation);
+            return namedGroundStation;
         }
 
         public static bool AntennaHasConnection(Part part)
@@ -161,6 +174,20 @@ namespace RemoteTech.API
             }
 
             return groundStation.mGuid;
+        }
+
+        /// <summary> Gets the name of a satellite.</summary>
+        /// <param name="id">The satellite id.</param>
+        /// <returns>name of the satellite with matching id if found, otherwise null</returns>
+        public static string GetName(Guid id)
+        {
+            if (RTCore.Instance == null) return null;
+            var satellite = RTCore.Instance.Satellites[id];
+            if (satellite == null) return null;
+
+            string satellitename = satellite.Name;
+            RTLog.Verbose("APIcall: {0} is named {1}", RTLogLevel.API, id, satellitename);
+            return satellitename;
         }
 
         public static Guid GetCelestialBodyGuid(CelestialBody celestialBody)

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -417,8 +417,8 @@ namespace RemoteTech.API
             var satellite = RTCore.Instance.Satellites[id];
             if (satellite == null) return false;
 
-            satellite.IsInPowerDown = flag;
-            RTLog.Verbose("Flight: {0} has power down flag updated due to reason '{2}': {1}", RTLogLevel.API, id, satellite.IsInPowerDown, reason);
+            satellite.PowerShutdownFlag = flag;
+            RTLog.Verbose("Flight: {0} has power down flag updated due to reason '{2}': {1}", RTLogLevel.API, id, satellite.PowerShutdownFlag, reason);
             return true;
         }
 
@@ -432,9 +432,9 @@ namespace RemoteTech.API
             var satellite = RTCore.Instance.Satellites[id];
             if (satellite == null) return false;
 
-            var powerdownFlag = satellite.IsInPowerDown;
-            RTLog.Verbose("Flight: {0} is in power down: {1}", RTLogLevel.API, id, powerdownFlag);
-            return powerdownFlag;
+            var flag = satellite.PowerShutdownFlag;
+            RTLog.Verbose("Flight: {0} is in power down: {1}", RTLogLevel.API, id, flag);
+            return flag;
         }
     }
 }

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -100,6 +100,22 @@ namespace RemoteTech.API
             return connectedToKerbin;
         }
 
+        /// <summary>
+        /// Determines if a vessel directly targets a ground station.
+        /// </summary>
+        /// <param name="id">The vessels id.</param>
+        /// <returns>true if the vessel has an antenna with a ground station as its first link, false otherwise.</returns>
+        public static bool HasGroundStationTarget(Guid id)
+        {
+            if (RTCore.Instance == null) return false;
+            var satellite = RTCore.Instance.Satellites[id];
+            if (satellite == null) return false;
+
+            var targetsGroundStation = RTCore.Instance.Network[satellite].Any(r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Links.FirstOrDefault().Target.Guid));
+            RTLog.Verbose("APIcall: {0} Directly targets a ground station {1}", RTLogLevel.API, id, targetsGroundStation);
+            return targetsGroundStation;
+        }
+
         public static bool AntennaHasConnection(Part part)
         {
             if (RTCore.Instance == null) return false;

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -23,8 +23,12 @@ namespace RemoteTech.API
         public static void EnableInSPC(bool state)  // its advised that modders who need RTCore active in the SPC should set this from the MainMenu Scene
         {
             enabledInSPC = state;  // setting to true will only take effect after a scene change
+            RTLog.Verbose("Flag for RemoteTech running in Space Center scene is set: {0}", RTLogLevel.API, enabledInSPC);
             if (!enabledInSPC && RTCore.Instance != null && HighLogic.LoadedScene == GameScenes.SPACECENTER)
+            {
+                RTLog.Verbose("RemoteTech is terminated in Space Center scene", RTLogLevel.API);
                 RTCore.Instance.OnDestroy();
+            }
         }
 
         public static bool HasLocalControl(Guid id)
@@ -103,21 +107,21 @@ namespace RemoteTech.API
         /// <summary> Determines if a satellite directly targets a ground station.</summary>
         /// <param name="id">The satellite id.</param>
         /// <returns>true if the satellite has an antenna with a ground station as its first link, false otherwise.</returns>
-        public static bool HasGroundStationTarget(Guid id)
+        public static bool HasDirectGroundStation(Guid id)
         {
             if (RTCore.Instance == null) return false;
             var satellite = RTCore.Instance.Satellites[id];
             if (satellite == null) return false;
 
             var targetsGroundStation = RTCore.Instance.Network[satellite].Any(r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Links.FirstOrDefault().Target.Guid));
-            RTLog.Verbose("APIcall: {0} Directly targets a ground station {1}", RTLogLevel.API, id, targetsGroundStation);
+            RTLog.Verbose("Flight: {0} Directly targets a ground station: {1}", RTLogLevel.API, id, targetsGroundStation);
             return targetsGroundStation;
         }
 
         /// <summary> Gets the name of the ground station directly targeted with the shortest link to the satellite.</summary>
         /// <param name="id">The satellite id.</param>
         /// <returns>name of the ground station if one is found, null otherwise.</returns>
-        public static string GetNameGroundStationTarget(Guid id)
+        public static string GetClosestDirectGroundStation(Guid id)
         {
             if (RTCore.Instance == null) return null;
             var satellite = RTCore.Instance.Satellites[id];
@@ -125,14 +129,14 @@ namespace RemoteTech.API
 
             var namedGroundStation = RTCore.Instance.Network[satellite].Where
                 (r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Links.FirstOrDefault().Target.Guid)).Min().Goal.Name;
-            RTLog.Verbose("APIcall: {0} Directly targets with the shortest link the ground station {1}", RTLogLevel.API, id, namedGroundStation);
+            RTLog.Verbose("Flight: {0} Directly targets the closest ground station: {1}", RTLogLevel.API, id, namedGroundStation);
             return namedGroundStation;
         }
 
         /// <summary> Gets the name of the first hop satellite with the shortest link to KSC by the specified satellite.</summary>
         /// <param name="id">The satellite id.</param>
         /// <returns>name of the satellite if one is found, null otherwise.</returns>
-        public static string GetFirstHopNameToKSC(Guid id)
+        public static string GetFirstHopToKSC(Guid id)
         {
             if (RTCore.Instance == null) return null;
             var satellite = RTCore.Instance.Satellites[id];
@@ -140,7 +144,7 @@ namespace RemoteTech.API
 
             var namedSatellite = RTCore.Instance.Network[satellite].Where
                 (r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Goal.Guid)).Min().Links.FirstOrDefault().Target.Name;
-            RTLog.Verbose("APIcall: {0} Shortest route to KSC has as its first hop the satellite named {1}", RTLogLevel.API, id, namedSatellite);
+            RTLog.Verbose("Flight: {0} Has first hop satellite with shortest link to KSC: {1}", RTLogLevel.API, id, namedSatellite);
             return namedSatellite;
         }
 
@@ -201,7 +205,7 @@ namespace RemoteTech.API
             if (satellite == null) return null;
 
             string satellitename = satellite.Name;
-            RTLog.Verbose("APIcall: {0} is named {1}", RTLogLevel.API, id, satellitename);
+            RTLog.Verbose("Flight: {0} is: {1}", RTLogLevel.API, id, satellitename);
             return satellitename;
         }
 
@@ -409,11 +413,9 @@ namespace RemoteTech.API
         /// <returns>Indicator on whether this request is executed successfully</returns>
         public static bool SetPowerDownGuid(Guid id, bool flag, string reason = "")
         {
-            if (RTCore.Instance == null)
-                return false;
+            if (RTCore.Instance == null) return false;
             var satellite = RTCore.Instance.Satellites[id];
-            if (satellite == null)
-                return false;
+            if (satellite == null) return false;
 
             satellite.IsInPowerDown = flag;
             RTLog.Verbose("Flight: {0} has power down flag updated due to reason '{2}': {1}", RTLogLevel.API, id, satellite.IsInPowerDown, reason);
@@ -426,11 +428,9 @@ namespace RemoteTech.API
         /// <returns>Indicator on whether target vessel is in power down state</returns>
         public static bool GetPowerDownGuid(Guid id)
         {
-            if (RTCore.Instance == null)
-                return false;
+            if (RTCore.Instance == null) return false;
             var satellite = RTCore.Instance.Satellites[id];
-            if (satellite == null)
-                return false;
+            if (satellite == null) return false;
 
             var powerdownFlag = satellite.IsInPowerDown;
             RTLog.Verbose("Flight: {0} is in power down: {1}", RTLogLevel.API, id, powerdownFlag);

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -334,5 +334,39 @@ namespace RemoteTech.API
             RTLog.Verbose("Flight: {0} is in radio blackout: {1}", RTLogLevel.API, id, blackoutFlag);
             return blackoutFlag;
         }
+
+        /// <summary>
+        /// Enforce or remove the power down on target vessel
+        /// </summary>
+        /// <returns>Indicator on whether this request is executed successfully</returns>
+        public static bool SetPowerDownGuid(Guid id, bool flag, string reason = "")
+        {
+            if (RTCore.Instance == null)
+                return false;
+            var satellite = RTCore.Instance.Satellites[id];
+            if (satellite == null)
+                return false;
+
+            satellite.IsInPowerDown = flag;
+            RTLog.Verbose("Flight: {0} has power down flag updated due to reason '{2}': {1}", RTLogLevel.API, id, satellite.IsInPowerDown, reason);
+            return true;
+        }
+
+        /// <summary>
+        /// Check if target vessel is currently in power down state
+        /// </summary>
+        /// <returns>Indicator on whether target vessel is in power down state</returns>
+        public static bool GetPowerDownGuid(Guid id)
+        {
+            if (RTCore.Instance == null)
+                return false;
+            var satellite = RTCore.Instance.Satellites[id];
+            if (satellite == null)
+                return false;
+
+            var powerdownFlag = satellite.IsInPowerDown;
+            RTLog.Verbose("Flight: {0} is in power down: {1}", RTLogLevel.API, id, powerdownFlag);
+            return powerdownFlag;
+        }
     }
 }

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -101,7 +101,7 @@ namespace RemoteTech.API
         }
 
         /// <summary> Determines if a satellite directly targets a ground station.</summary>
-        /// <param name="id">The vessels id.</param>
+        /// <param name="id">The satellite id.</param>
         /// <returns>true if the satellite has an antenna with a ground station as its first link, false otherwise.</returns>
         public static bool HasGroundStationTarget(Guid id)
         {
@@ -115,7 +115,7 @@ namespace RemoteTech.API
         }
 
         /// <summary> Gets the name of the ground station directly targeted with the shortest link to the satellite.</summary>
-        /// <param name="id">The vessels id.</param>
+        /// <param name="id">The satellite id.</param>
         /// <returns>name of the ground station if one is found, null otherwise.</returns>
         public static string GetNameGroundStationTarget(Guid id)
         {
@@ -127,6 +127,21 @@ namespace RemoteTech.API
                 (r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Links.FirstOrDefault().Target.Guid)).Min().Goal.Name;
             RTLog.Verbose("APIcall: {0} Directly targets with the shortest link the ground station {1}", RTLogLevel.API, id, namedGroundStation);
             return namedGroundStation;
+        }
+
+        /// <summary> Gets the name of the first hop satellite with the shortest link to KSC by the specified satellite.</summary>
+        /// <param name="id">The satellite id.</param>
+        /// <returns>name of the satellite if one is found, null otherwise.</returns>
+        public static string GetFirstHopNameToKSC(Guid id)
+        {
+            if (RTCore.Instance == null) return null;
+            var satellite = RTCore.Instance.Satellites[id];
+            if (satellite == null) return null;
+
+            var namedSatellite = RTCore.Instance.Network[satellite].Where
+                (r => RTCore.Instance.Network.GroundStations.ContainsKey(r.Goal.Guid)).Min().Links.FirstOrDefault().Target.Name;
+            RTLog.Verbose("APIcall: {0} Shortest route to KSC has as its first hop the satellite named {1}", RTLogLevel.API, id, namedSatellite);
+            return namedSatellite;
         }
 
         public static bool AntennaHasConnection(Part part)

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -19,7 +19,7 @@ namespace RemoteTech.API
 
         public static bool HasLocalControl(Guid id)
         {
-            var vessel = RTUtil.GetVesselById(id);            
+            var vessel = RTUtil.GetVesselById(id);
             if (vessel == null) return false;
 
             RTLog.Verbose("Flight: {0} HasLocalControl: {1}", RTLogLevel.API, id, vessel.HasLocalControl());
@@ -213,10 +213,10 @@ namespace RemoteTech.API
                     return false;
                 }
 
-                // maybe we should look if this vessel hasLocal controll or not. If so, we can execute the command
+                // maybe we should look if this vessel hasLocal control or not. If so, we can execute the command
                 // immediately
 
-                // get the flightcomputer
+                // get the flight computer
                 FlightComputer.FlightComputer computer = RTCore.Instance.Satellites[externalVesselId].FlightComputer;
 
                 var extCmd = FlightComputer.Commands.ExternalAPICommand.FromExternal(externalData);
@@ -248,7 +248,7 @@ namespace RemoteTech.API
 
 		public static Guid AddGroundStation(string name, double latitude, double longitude, double height, int body)
 		{
-			RTLog.Notify ("Trying to add groundstation {0}", RTLogLevel.API, name);
+			RTLog.Notify ("Trying to add ground station {0}", RTLogLevel.API, name);
             Guid newStationId = RTSettings.Instance.AddGroundStation(name, latitude, longitude, height, body);
 
             return newStationId;
@@ -256,10 +256,10 @@ namespace RemoteTech.API
 
 		public static bool RemoveGroundStation(Guid stationid)
 		{
-			RTLog.Notify ("Trying to remove groundstation {0}", RTLogLevel.API, stationid);
+			RTLog.Notify ("Trying to remove ground station {0}", RTLogLevel.API, stationid);
 
             // do not allow to remove the default mission control
-			if (stationid.ToString ("N").Equals ("5105f5a9d62841c6ad4b21154e8fc488")) 
+			if (stationid.ToString ("N").Equals ("5105f5a9d62841c6ad4b21154e8fc488"))
 			{
 				RTLog.Notify ("Cannot remove KSC Mission Control!", RTLogLevel.API);
 				return false;
@@ -277,7 +277,7 @@ namespace RemoteTech.API
         /// <returns>true if the ground station antenna range was changed, false otherwise.</returns>
         public static bool ChangeGroundStationRange(Guid stationId, float newRange)
         {
-            RTLog.Notify("Trying to change groundstation {0} Omni range to {1}", RTLogLevel.API, stationId.ToString(), newRange);
+            RTLog.Notify("Trying to change ground station {0} Omni range to {1}", RTLogLevel.API, stationId.ToString(), newRange);
 
             if (RTSettings.Instance == null)
                 return false;
@@ -296,9 +296,9 @@ namespace RemoteTech.API
                     if (antenna is MissionControlAntenna)
                     {
                         ((MissionControlAntenna)antenna).SetOmniAntennaRange(newRange);
-                        RTLog.Notify("Ground station Omni range successfuly chaned.", RTLogLevel.API);
+                        RTLog.Notify("Ground station Omni range successfully changed.", RTLogLevel.API);
                         return true;
-                    }                    
+                    }
                 }
             }
 

--- a/src/RemoteTech/API/API.cs
+++ b/src/RemoteTech/API/API.cs
@@ -11,10 +11,20 @@ namespace RemoteTech.API
 {
     public static class API
     {
+        /// <summary>If true then RTCore will be available in the Space Center</summary>
+        internal static bool enabledInSPC = false;
+
         public static bool IsRemoteTechEnabled()
         {
             if (RTCore.Instance != null) return true;
             return false;
+        }
+
+        public static void EnableInSPC(bool state)  // its advised that modders who need RTCore active in the SPC should set this from the MainMenu Scene
+        {
+            enabledInSPC = state;  // setting to true will only take effect after a scene change
+            if (!enabledInSPC && RTCore.Instance != null && HighLogic.LoadedScene == GameScenes.SPACECENTER)
+                RTCore.Instance.OnDestroy();
         }
 
         public static bool HasLocalControl(Guid id)

--- a/src/RemoteTech/ISatellite.cs
+++ b/src/RemoteTech/ISatellite.cs
@@ -40,7 +40,7 @@ namespace RemoteTech
         bool CanRelaySignal { get; }
         /// <summary>Indicates whether the satellite is in radio blackout.</summary>
         bool IsInRadioBlackout { get; set; }
-        /// <summary>Indicates whether the satellite is in a powered down state.</summary>
-        bool IsInPowerDown { get; set; }
+        /// <summary>Indicates whether the manual power override is engaged.</summary>
+        bool PowerShutdownFlag { get; set; }
     }
 }

--- a/src/RemoteTech/ISatellite.cs
+++ b/src/RemoteTech/ISatellite.cs
@@ -40,5 +40,7 @@ namespace RemoteTech
         bool CanRelaySignal { get; }
         /// <summary>Indicates whether the satellite is in radio blackout.</summary>
         bool IsInRadioBlackout { get; set; }
+        /// <summary>Indicates whether the satellite is in a powered down state.</summary>
+        bool IsInPowerDown { get; set; }
     }
 }

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -146,6 +146,7 @@ namespace RemoteTech
         {
             if (sat_a == null || sat_b == null || sat_a == sat_b) return null;
             if (sat_a.IsInRadioBlackout || sat_b.IsInRadioBlackout) return null;
+            if (sat_a.IsInPowerDown || sat_b.IsInPowerDown) return null;
             bool los = sat_a.HasLineOfSightWith(sat_b) || RTSettings.Instance.IgnoreLineOfSight;
             if (!los) return null;
 
@@ -261,6 +262,7 @@ namespace RemoteTech
         public Guid mGuid { get; private set; }
         public IEnumerable<IAntenna> MissionControlAntennas { get { return Antennas; } }
         public bool IsInRadioBlackout { get; set; } // could be EMP
+        public bool IsInPowerDown { get; set; } // could be dead battery
 
         void ISatellite.OnConnectionRefresh(List<NetworkRoute<ISatellite>> route) { }
 

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -173,7 +173,8 @@ namespace RemoteTech
 
                 // amend this optimisation due to inconsistent connectivity on non-active vessels (eg showing no connection when 3rd-party mods query)
                 //if (s.SignalProcessor.VesselLoaded || HighLogic.LoadedScene == GameScenes.TRACKSTATION || RTCore.Instance.Renderer.ShowMultiPath)
-                if (HighLogic.LoadedScene == GameScenes.TRACKSTATION || HighLogic.LoadedScene == GameScenes.FLIGHT || HighLogic.LoadedScene == GameScenes.SPACECENTER)
+                if (HighLogic.LoadedScene == GameScenes.TRACKSTATION || HighLogic.LoadedScene == GameScenes.FLIGHT ||
+                    (HighLogic.LoadedScene == GameScenes.SPACECENTER && API.API.enabledInSPC))
                 {
                     FindPath(s, commandStations);
                 }

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -146,7 +146,6 @@ namespace RemoteTech
         {
             if (sat_a == null || sat_b == null || sat_a == sat_b) return null;
             if (sat_a.IsInRadioBlackout || sat_b.IsInRadioBlackout) return null;
-            if (sat_a.IsInPowerDown || sat_b.IsInPowerDown) return null;
             bool los = sat_a.HasLineOfSightWith(sat_b) || RTSettings.Instance.IgnoreLineOfSight;
             if (!los) return null;
 
@@ -246,7 +245,7 @@ namespace RemoteTech
 
         private bool AntennaActivated = true;
 
-        bool ISatellite.Powered { get { return this.AntennaActivated; } }
+        bool ISatellite.Powered { get { return PowerShutdownFlag ? false : this.AntennaActivated; } }
         bool ISatellite.Visible { get { return true; } }
         String ISatellite.Name { get { return Name; } set { Name = value; } }
         Guid ISatellite.Guid { get { return mGuid; } }
@@ -263,7 +262,7 @@ namespace RemoteTech
         public Guid mGuid { get; private set; }
         public IEnumerable<IAntenna> MissionControlAntennas { get { return Antennas; } }
         public bool IsInRadioBlackout { get; set; } // could be EMP
-        public bool IsInPowerDown { get; set; } // could be dead battery
+        public bool PowerShutdownFlag { get; set; } // flag for third-party realism mods
 
         void ISatellite.OnConnectionRefresh(List<NetworkRoute<ISatellite>> route) { }
 

--- a/src/RemoteTech/NetworkManager.cs
+++ b/src/RemoteTech/NetworkManager.cs
@@ -173,7 +173,7 @@ namespace RemoteTech
 
                 // amend this optimisation due to inconsistent connectivity on non-active vessels (eg showing no connection when 3rd-party mods query)
                 //if (s.SignalProcessor.VesselLoaded || HighLogic.LoadedScene == GameScenes.TRACKSTATION || RTCore.Instance.Renderer.ShowMultiPath)
-                if (HighLogic.LoadedScene == GameScenes.TRACKSTATION || HighLogic.LoadedScene == GameScenes.FLIGHT)
+                if (HighLogic.LoadedScene == GameScenes.TRACKSTATION || HighLogic.LoadedScene == GameScenes.FLIGHT || HighLogic.LoadedScene == GameScenes.SPACECENTER)
                 {
                     FindPath(s, commandStations);
                 }

--- a/src/RemoteTech/RTCore.cs
+++ b/src/RemoteTech/RTCore.cs
@@ -399,6 +399,25 @@ namespace RemoteTech
     }
 
     /// <summary>
+    /// Main class, instantiated during Space Center scene. Allows mods to access connection data via API from the Space Center scene
+    /// </summary>
+    [KSPAddon(KSPAddon.Startup.SpaceCentre, false)]
+    public class RTCoreSpaceCenter: RTCore
+    {
+        public new void Start()
+        {
+            base.Start();
+            if (Instance == null)
+                return;
+        }
+
+        private new void OnDestroy()
+        {
+            base.OnDestroy();
+        }
+    }
+
+    /// <summary>
     /// Main class, instantiated during Main menu scene.
     /// </summary>
     [KSPAddon(KSPAddon.Startup.MainMenu, false)]

--- a/src/RemoteTech/RTCore.cs
+++ b/src/RemoteTech/RTCore.cs
@@ -406,8 +406,19 @@ namespace RemoteTech
     {
         public new void Start()
         {
-            if (API.API.enabledInSPC) base.Start();
-            else base.OnDestroy();
+            if (API.API.enabledInSPC)
+            {
+                base.Start();
+                if (Instance == null)
+                    return;
+            }
+            else
+            {
+                if (Instance != null)
+                {
+                }
+                base.OnDestroy();
+            }
         }
 
         private new void OnDestroy()

--- a/src/RemoteTech/RTCore.cs
+++ b/src/RemoteTech/RTCore.cs
@@ -406,9 +406,8 @@ namespace RemoteTech
     {
         public new void Start()
         {
-            base.Start();
-            if (Instance == null)
-                return;
+            if (API.API.enabledInSPC) base.Start();
+            else base.OnDestroy();
         }
 
         private new void OnDestroy()

--- a/src/RemoteTech/VesselSatellite.cs
+++ b/src/RemoteTech/VesselSatellite.cs
@@ -52,6 +52,9 @@ namespace RemoteTech
         /// <summary>Indicates whether the satellite is in radio blackout.</summary>
         public bool IsInRadioBlackout { get; set; }
 
+        /// <summary>Indicates whether the satellite is in a powered down state.</summary>
+        public bool IsInPowerDown { get; set; }
+
         /// <summary>Gets if the satellite is a RemoteTech command station.</summary>
         public bool IsCommandStation
         {

--- a/src/RemoteTech/VesselSatellite.cs
+++ b/src/RemoteTech/VesselSatellite.cs
@@ -40,7 +40,7 @@ namespace RemoteTech
         /// <summary>Gets if the satellite is actually powered or not.</summary>
         public bool Powered
         {
-            get { return SignalProcessors.Any(s => s.Powered); }
+            get { return (PowerShutdownFlag)? false : SignalProcessors.Any(s => s.Powered); }
         }
 
         /// <summary>Gets if the satellite is capable to forward other signals.</summary>
@@ -52,8 +52,8 @@ namespace RemoteTech
         /// <summary>Indicates whether the satellite is in radio blackout.</summary>
         public bool IsInRadioBlackout { get; set; }
 
-        /// <summary>Indicates whether the satellite is in a powered down state.</summary>
-        public bool IsInPowerDown { get; set; }
+        /// <summary>Indicates whether the manual power override is engaged.</summary>
+        public bool PowerShutdownFlag { get; set; }
 
         /// <summary>Gets if the satellite is a RemoteTech command station.</summary>
         public bool IsCommandStation


### PR DESCRIPTION
Added two methods for a Power Down state.
* `SetPowerDownGuid` method enables/disables a `satellite.IsInPowerDown` mode.
* `GetPowerDownGuid` method returns the state of the `satellite.IsInPowerDown` mode.

I created this functionality for Kerbalism so we can disable satellites when EC is Zero.
I could not use the `IsInRadioBlackout` as it was conflicting with our Blackout system due to it using `IsInRadioBlackout` to detect if the satellite is in Blackout, we do this just in case another mod sets this flag independently of Kerbalism's CME Storms. Setting `IsInRadioBlackout` as a workaround for loss of power would trigger our signals display to show a Blackout for the satellite when there was none.
Adding a check to not show the Blackout condition when EC was zero caused the signals display to show no Blackout when a Blackout condition existed and EC was Zero 👿

Works identically to the `IsInRadioBlackout` flag.
Could probably be implemented better but I did not want to go messing with your code too much since I am not familiar with your project source.

-----
Added an `RTCoreSpaceCenter` Class which allows mods to access connection data via API from the Space Center scene. This is needed by Kerbalism to allow it to show connection details in the Space Center Monitor display.
The `RTCoreSpaceCenter` Class is enabled/disabled via an API method `EnableInSPC`

-----
Added a method to determine if a vessel directly targets a ground station. Kerbalism uses this to determine if a vessel is directly linked to the KSC or if the connection to KSC is via a relay connection.
Also a method to retrieve the name of the directly targeted ground station with the shortest link and a method to retrieve the name of the first hop satellite to KSC with the shortest link, used for the Signal monitor tooltip in Kerbalism.
* `HasGroundStationTarget`
* `GetNameGroundStationTarget`
* `GetFirstHopNameToKSC`

-----
Added a method to retrieve the names of satellites. Kerbalism uses this to display names in its signals tooltip.
* `GetName` method retrieves the name of a satellite with the specified Guid.
