### PR TITLE
Better precision display of EC when Kerbalism is installed

### DIFF
--- a/src/RemoteTech/AddOns/Kerbalism.cs
+++ b/src/RemoteTech/AddOns/Kerbalism.cs
@@ -1,0 +1,31 @@
+﻿using System;
+
+
+namespace RemoteTech.AddOns
+{
+    /// <summary> Simple class to detect if Kerbalism is loaded </summary>
+    public static class Kerbalism
+    {
+        private static readonly Type API;
+
+        // constructor
+        static Kerbalism()
+        {
+            foreach (AssemblyLoader.LoadedAssembly a in AssemblyLoader.loadedAssemblies)
+            {
+                if (a.name == "Kerbalism")
+                {
+                    API = a.assembly.GetType("KERBALISM.API");
+                    break;
+                }
+            }
+        }
+
+        /// <summary> Returns true if Kerbalism is detected for the current game </summary>
+        public static bool Exists
+        {
+            get { return API != null; }
+        }
+    }
+}
+

--- a/src/RemoteTech/RTUtil.cs
+++ b/src/RemoteTech/RTUtil.cs
@@ -157,7 +157,7 @@ namespace RemoteTech
             String timeindicator = "sec";
 
             // Disabled to follow the stock consumption format unless Kerbalism is detected which requires higher precision due to EC costs being much lower
-            if(AddOns.Kerbalism.Exists && consumption < 1)
+            if(AddOns.Kerbalism.Exists && consumption < 0.01)
             {
                 // minutes
                 consumption *= 60;

--- a/src/RemoteTech/RTUtil.cs
+++ b/src/RemoteTech/RTUtil.cs
@@ -156,16 +156,15 @@ namespace RemoteTech
         {
             String timeindicator = "sec";
 
-            /* Disabled to follow the stock consumption format
-            if(consumption < 1)
+            // Disabled to follow the stock consumption format unless Kerbalism is detected which requires higher precision due to EC costs being much lower
+            if(AddOns.Kerbalism.Exists && consumption < 1)
             {
                 // minutes
                 consumption *= 60;
                 timeindicator = "min";
             }
-            */
-            
-            return String.Format("{0:F2}/{1}.", consumption, timeindicator);
+
+            return AddOns.Kerbalism.Exists ? String.Format("{0:F3}/{1}.", consumption, timeindicator) : String.Format("{0:F2}/{1}.", consumption, timeindicator);
         }
 
         public static String FormatSI(double value, String unit)

--- a/src/RemoteTech/RemoteTech.csproj
+++ b/src/RemoteTech/RemoteTech.csproj
@@ -65,6 +65,7 @@
   </ItemGroup>
   <ItemGroup>
     <Compile Include="AddOns\KerbalAlarmClockAPI.cs" />
+    <Compile Include="AddOns\Kerbalism.cs" />
     <Compile Include="API\API.cs" />
     <Compile Include="FlightComputer\Commands\AbstractCommand.cs" />
     <Compile Include="FlightComputer\Commands\EventCommand.cs" />


### PR DESCRIPTION
`FormatConsumption` method will display better precision when Kerbalism is detected, needed due to Kerbalism EC costs being much lower than standard RT.

Added a very simple class that detects the presence of Kerbalism into AddOns.

Helps to stop users with Kerbalism being confused when they see something like 0.00/sec rather than 0.240/min

### Before:
![screenshot0](https://user-images.githubusercontent.com/17555434/45596083-0b4f6200-b9ae-11e8-90c8-afe1e4a20767.png)

### After:
![screenshot0](https://user-images.githubusercontent.com/17555434/45596093-28843080-b9ae-11e8-856d-2410a4da4a08.png)
