### PR TITLE
#768 - Added ModuleManager patches for _v2 probes

### DIFF
--- a/GameData/RemoteTech/RemoteTech_Squad_Probes.cfg
+++ b/GameData/RemoteTech/RemoteTech_Squad_Probes.cfg
@@ -18,6 +18,23 @@
 	}
 }
 
+@PART[probeCoreSphere_v2]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}
+
 @PART[probeStackLarge]:FOR[RemoteTech]
 {
 	%MODULE[ModuleSPU] {
@@ -71,6 +88,23 @@
 	}
 }
 
+@PART[probeCoreOcto_v2]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}
+
 @PART[probeCoreOcto2]:FOR[RemoteTech]
 {
 	%MODULE[ModuleSPU] {
@@ -88,7 +122,41 @@
 	}
 }
 
+@PART[probeCoreOcto2_v2]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}
+
 @PART[probeCoreHex]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}
+
+@PART[probeCoreHex_v2]:FOR[RemoteTech]
 {
 	%MODULE[ModuleSPU] {
 	}
@@ -140,6 +208,23 @@
 }
 
 @PART[roverBody]:FOR[RemoteTech]
+{
+	%MODULE[ModuleSPU] {
+	}
+	
+	%MODULE[ModuleRTAntennaPassive]	{
+		%TechRequired = unmannedTech
+		%OmniRange = 3000
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.3
+			%PacketSize = 2
+			%PacketResourceCost = 15.0
+		}
+	}
+}
+
+@PART[roverBody_v2]:FOR[RemoteTech]
 {
 	%MODULE[ModuleSPU] {
 	}


### PR DESCRIPTION
When using the new probes in KSP 1.5, "local control" is always active. This is due to KSP 1.5 Introducing new probes with "_v2" in the name.

Updated the ModuleManager patches
