### PR TITLE
Support for Universal Storage 2

### DIFF
--- a/GameData/RemoteTech/RemoteTech_UniversalStorage2_Probes.cfg
+++ b/GameData/RemoteTech/RemoteTech_UniversalStorage2_Probes.cfg
@@ -1,0 +1,39 @@
+// Support for Universal Storage 2 probes
+// Contributed by NullSnapshot
+
+
+// Universal Storage: Remote Operations System
+@PART[USDoubleProbeCore]:AFTER[UniversalStorage2]:NEEDS[RemoteTech]
+{
+        %MODULE[ModuleSPU] {
+        }
+
+        %MODULE[ModuleRTAntennaPassive] {
+                %TechRequired = unmannedTech
+                %OmniRange    = 3000
+
+                %TRANSMITTER {
+                        %PacketInterval     = 0.3
+                        %PacketSize         = 2
+                        %PacketResourceCost = 15.0
+                }
+        }
+}
+
+// Universal Storage: Remote Operations System MKII
+@PART[USSingleProbeCore]:AFTER[UniversalStorage2]:NEEDS[RemoteTech]
+{
+        %MODULE[ModuleSPU] {
+        }
+
+        %MODULE[ModuleRTAntennaPassive] {
+                %TechRequired = unmannedTech
+                %OmniRange    = 3000
+
+                %TRANSMITTER {
+                        %PacketInterval     = 0.3
+                        %PacketSize         = 2
+                        %PacketResourceCost = 15.0
+                }
+        }
+}


### PR DESCRIPTION
Universal Storage has 2 integrated probe cores. Patch file adds the necessary SPU and antenna for them.

As a heads-up, this is based on the current 1.9.1 Beta 5 build of US2. I don't see this changing as I haven't experienced any issues with them, but just wanted to make sure whomever it concerns is aware. 