### PR TITLE
Duplicate config for HighGainAntenna5 for 1.11

### DIFF
--- a/GameData/RemoteTech/RemoteTech_Squad_Antennas.cfg
+++ b/GameData/RemoteTech/RemoteTech_Squad_Antennas.cfg
@@ -156,7 +156,7 @@
 	%MODULE[ModuleSPUPassive] {}
 }
 
-
+// HG-5 High Gain Antenna for KSP < v1.11
 @PART[HighGainAntenna5]:FOR[RemoteTech]
 {
 	@MODULE[ModuleDeployableAntenna]
@@ -188,6 +188,40 @@
 	
 	%MODULE[ModuleSPUPassive] {}
 }
+
+// HG-5 High Gain Antenna for KSP >= v1.11
+@PART[HighGainAntenna5_v2]:FOR[RemoteTech]
+{
+	@MODULE[ModuleDeployableAntenna]
+	{
+		%name=ModuleAnimateGeneric
+		%allowManualControl = false
+		%actionAvailable = false
+		%eventAvailableFlight = false
+		%eventAvailableEditor = false
+		%eventAvailableEVA = false
+	}
+	
+	%MODULE[ModuleRTAntenna] {
+		%Mode0DishRange = 0
+		%Mode1DishRange = 20000000
+		%EnergyCost = 0.55
+		%MaxQ = 6000
+		%DishAngle = 90
+		
+		%DeployFxModules = 0
+		%ProgressFxModules = 1
+		
+		%TRANSMITTER {
+			%PacketInterval = 0.15
+			%PacketSize = 3
+			%PacketResourceCost = 20.0
+		}
+	}
+	
+	%MODULE[ModuleSPUPassive] {}
+}
+
 
 @PART[RelayAntenna100]:FOR[RemoteTech]
 {


### PR DESCRIPTION
This change duplicates the HighGainAntenna for KSP 1.11 to reflect the v2 part.