### PR TITLE
Update RoverComputer.cs

### DIFF
--- a/src/RemoteTech/FlightComputer/RoverComputer.cs
+++ b/src/RemoteTech/FlightComputer/RoverComputer.cs
@@ -81,7 +81,7 @@ namespace RemoteTech.FlightComputer
 
         public RoverComputer(FlightComputer fc, double kp, double ki, double kd)
         {
-            throttlePID = new PIDLoop(1, 0, 0);
+            throttlePID = new PIDLoop(1, 0.5, 0);
             steerPID = new PIDLoop(1, 0, 0);
 
             pidController = fc.PIDController; //don't think of putting second copy of PID here


### PR DESCRIPTION
ThrottlePID needs a non-zero Ki to be able to keep the speed down slope. With Ki=0 it underthrottles, which, combined with game's torque curve implementation (the faster you go, the less torque budget you have) creates a positive feedback loop.