### PR TITLE
fix NetworkRenderer still drawing in SpaceCenter scene when API.enabledInSPC is true

### DIFF
--- a/src/RemoteTech/NetworkRenderer.cs
+++ b/src/RemoteTech/NetworkRenderer.cs
@@ -104,7 +104,7 @@ namespace RemoteTech
 
         public void OnPreCull()
         {
-            if (MapView.MapIsEnabled)
+            if (MapView.MapIsEnabled && (HighLogic.LoadedScene != GameScenes.SPACECENTER))
             {
                 UpdateNetworkEdges();
                 UpdateNetworkCones();

--- a/src/RemoteTech/NetworkRenderer.cs
+++ b/src/RemoteTech/NetworkRenderer.cs
@@ -113,7 +113,7 @@ namespace RemoteTech
 
         public void OnGUI()
         {
-            if (Event.current.type == EventType.Repaint && MapView.MapIsEnabled)
+            if (Event.current.type == EventType.Repaint && MapView.MapIsEnabled && (HighLogic.LoadedScene != GameScenes.SPACECENTER))
             {
                 foreach (ISatellite s in RTCore.Instance.Satellites.FindCommandStations().Concat(RTCore.Instance.Network.GroundStations.Values))
                 {


### PR DESCRIPTION
fix for the NetworkRenderer when API.enabledInSPC is on. When switching from the Flight-MapView to SpaceCenter, the KSP MapView.MapIsEnabled is still true, thus resulting in this bug. The fix is simple and should definitely not break anything else.