### PR TITLE
Update compatibility for KSP 1.12.5

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,3 +1,22 @@
+# Version 1.9.13
+**Released TBD**
+
+What's New?
+===========
+
+* Recompiled for KSP 1.12.5
+
+Detailed Changelog
+==================
+
+Fixed Issues
+------------
+
+Pull Requests
+-------------
+
+***
+
 # Version 1.9.12
 **Released July 10, 2021**
 

--- a/GameData/RemoteTech/RemoteTech.version
+++ b/GameData/RemoteTech/RemoteTech.version
@@ -12,13 +12,13 @@
 	"VERSION":{
     "MAJOR":1,
     "MINOR":9,
-    "PATCH":12,
+    "PATCH":13,
     "BUILD":0
   },
   "KSP_VERSION":{
     "MAJOR":1,
     "MINOR":12,
-    "PATCH":1
+    "PATCH":5
   },
   "KSP_VERSION_MIN":{
     "MAJOR":1,
@@ -28,6 +28,6 @@
   "KSP_VERSION_MAX":{
     "MAJOR":1,
     "MINOR":12,
-    "PATCH":1
+    "PATCH":5
   }
 }

--- a/src/RemoteTech/Properties/AssemblyInfo.cs
+++ b/src/RemoteTech/Properties/AssemblyInfo.cs
@@ -37,7 +37,7 @@ using System.Runtime.InteropServices;
 // DLLs any time it changes.  Breaking on a minor revision is probably acceptable - it's
 // unlikely that there wouldn't be other breaking changes on a minor version change.
 [assembly: AssemblyVersion("1.9")]
-[assembly: AssemblyFileVersion("1.9.12")]
+[assembly: AssemblyFileVersion("1.9.13")]
 
 // Use KSPAssembly to allow other DLLs to make this DLL a dependency in a
 // non-hacky way in KSP.  Format is (AssemblyProduct, major, minor), and it


### PR DESCRIPTION
## Summary

- bump RemoteTech release metadata to `1.9.13`
- advertise compatibility through KSP `1.12.5`
- add a changelog stub for the compatibility rebuild

## Why

CKAN and AVC currently see the latest release as compatible through KSP 1.12.1. I rebuilt the plugin against a local KSP 1.12.5 install and updated the version metadata so maintainers have a small compatibility-update branch to review.

Related: #849

## Validation

Built locally on Linux with Mono/xbuild against KSP `1.12.5.3190` managed assemblies:

```sh
xbuild /p:Configuration=Release /p:PostBuildEvent= src/RemoteTech/RemoteTech.sln
```

Additional checks:

- `python -m json.tool GameData/RemoteTech/RemoteTech.version`
- `monodis --customattr GameData/RemoteTech/Plugins/RemoteTech.dll` shows `AssemblyFileVersion("1.9.13")`
- local package artifact inspected to confirm only `RemoteTech.dll` is included under `GameData/RemoteTech/Plugins/`

I did not run an in-game smoke test; opening as draft so maintainers can decide whether runtime QA or a different release version should be used.
